### PR TITLE
feat: expose additional pt-osc options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ The builder version will:
 | `criticalLoad`           | `number`                                                   | `undefined`                 | Passed to `--critical-load` (e.g. `Threads_running=50`)  |
 | `alterForeignKeysMethod` | `'auto' \| 'rebuild_constraints' \| 'drop_swap' \| 'none'` | `'auto'`                    | Passed to `--alter-foreign-keys-method`                  |
 | `ptoscPath`              | `string`                                                   | `'pt-online-schema-change'` | Path to pt-osc binary                                    |
+| `analyzeBeforeSwap`      | `boolean`                                                  | `true`                      | `--analyze-before-swap` or `--noanalyze-before-swap`    |
+| `checkAlter`             | `boolean`                                                  | `true`                      | `--check-alter` or `--nocheck-alter`                    |
+| `checkForeignKeys`       | `boolean`                                                  | `true`                      | `--check-foreign-keys` or `--nocheck-foreign-keys`      |
+| `checkInterval`          | `number`                                                   | `undefined`                 | Passed to `--check-interval`                             |
+| `checkPlan`              | `boolean`                                                  | `true`                      | `--check-plan` or `--nocheck-plan`                      |
+| `checkReplicationFilters`| `boolean`                                                  | `true`                      | `--check-replication-filters` or `--nocheck-replication-filters` |
+| `checkReplicaLag`        | `boolean`                                                  | `false`                     | Adds `--check-replica-lag`                               |
+| `chunkIndex`             | `string`                                                   | `undefined`                 | Passed to `--chunk-index`                                |
+| `chunkIndexColumns`      | `number`                                                   | `undefined`                 | Passed to `--chunk-index-columns`                        |
+| `chunkSize`              | `number`                                                   | `1000`                      | Passed to `--chunk-size`                                 |
+| `chunkSizeLimit`         | `number`                                                   | `4.0`                       | Passed to `--chunk-size-limit`                           |
+| `chunkTime`              | `number`                                                   | `0.5`                       | Passed to `--chunk-time`                                 |
+| `dropNewTable`           | `boolean`                                                  | `true`                      | `--drop-new-table` or `--nodrop-new-table`              |
+| `dropOldTable`           | `boolean`                                                  | `true`                      | `--drop-old-table` or `--nodrop-old-table`              |
+| `dropTriggers`           | `boolean`                                                  | `true`                      | `--drop-triggers` or `--nodrop-triggers`                |
+| `checkUniqueKeyChange`   | `boolean`                                                  | `true`                      | `--check-unique-key-change` or `--nocheck-unique-key-change` |
+| `maxLag`                 | `number`                                                   | `25`                        | Passed to `--max-lag`                                   |
 
 ---
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,23 @@ export interface PtoscOptions {
   criticalLoad?: number;     // Threads_running limit
   alterForeignKeysMethod?: 'auto' | 'rebuild_constraints' | 'drop_swap' | 'none';
   ptoscPath?: string;        // custom path to pt-online-schema-change
+  analyzeBeforeSwap?: boolean;
+  checkAlter?: boolean;
+  checkForeignKeys?: boolean;
+  checkInterval?: number;
+  checkPlan?: boolean;
+  checkReplicationFilters?: boolean;
+  checkReplicaLag?: boolean;
+  chunkIndex?: string;
+  chunkIndexColumns?: number;
+  chunkSize?: number;
+  chunkSizeLimit?: number;
+  chunkTime?: number;
+  dropNewTable?: boolean;
+  dropOldTable?: boolean;
+  dropTriggers?: boolean;
+  checkUniqueKeyChange?: boolean;
+  maxLag?: number;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { execFile } from 'child_process';
+import childProcess from 'child_process';
 
 const VALID_FOREIGN_KEYS_METHODS = ['auto', 'rebuild_constraints', 'drop_swap', 'none'];
 
@@ -67,7 +67,24 @@ function buildPtoscArgs({
   socketPath,
   maxLoad,
   criticalLoad,
-  dryRun
+  dryRun,
+  analyzeBeforeSwap = true,
+  checkAlter = true,
+  checkForeignKeys = true,
+  checkInterval,
+  checkPlan = true,
+  checkReplicationFilters = true,
+  checkReplicaLag = false,
+  chunkIndex,
+  chunkIndexColumns,
+  chunkSize = 1000,
+  chunkSizeLimit = 4.0,
+  chunkTime = 0.5,
+  dropNewTable = true,
+  dropOldTable = true,
+  dropTriggers = true,
+  checkUniqueKeyChange = true,
+  maxLag = 25
 }) {
   const args = [
     '--alter', alterSQL,
@@ -81,6 +98,23 @@ function buildPtoscArgs({
   if (socketPath) args.push('--socket', socketPath);
   if (maxLoad != null) args.push('--max-load', `Threads_connected=${maxLoad}`);
   if (criticalLoad != null) args.push('--critical-load', `Threads_running=${criticalLoad}`);
+  args.push(analyzeBeforeSwap ? '--analyze-before-swap' : '--noanalyze-before-swap');
+  args.push(checkAlter ? '--check-alter' : '--nocheck-alter');
+  args.push(checkForeignKeys ? '--check-foreign-keys' : '--nocheck-foreign-keys');
+  if (checkInterval != null) args.push('--check-interval', String(checkInterval));
+  args.push(checkPlan ? '--check-plan' : '--nocheck-plan');
+  args.push(checkReplicationFilters ? '--check-replication-filters' : '--nocheck-replication-filters');
+  if (checkReplicaLag) args.push('--check-replica-lag');
+  if (chunkIndex) args.push('--chunk-index', chunkIndex);
+  if (chunkIndexColumns != null) args.push('--chunk-index-columns', String(chunkIndexColumns));
+  if (chunkSize != null) args.push('--chunk-size', String(chunkSize));
+  if (chunkSizeLimit != null) args.push('--chunk-size-limit', String(chunkSizeLimit));
+  if (chunkTime != null) args.push('--chunk-time', String(chunkTime));
+  args.push(dropNewTable ? '--drop-new-table' : '--nodrop-new-table');
+  args.push(dropOldTable ? '--drop-old-table' : '--nodrop-old-table');
+  args.push(dropTriggers ? '--drop-triggers' : '--nodrop-triggers');
+  args.push(checkUniqueKeyChange ? '--check-unique-key-change' : '--nocheck-unique-key-change');
+  if (maxLag != null) args.push('--max-lag', String(maxLag));
   return args;
 }
 
@@ -97,7 +131,7 @@ async function runPtoscProcess({ ptoscPath = 'pt-online-schema-change', args, en
   logCommand(ptoscPath, args);
 
   await new Promise((resolve, reject) => {
-    execFile(ptoscPath, args, { env }, (err, stdout, stderr) => {
+    childProcess.execFile(ptoscPath, args, { env }, (err, stdout, stderr) => {
       if (stdout) console.log(stdout.trim());
       if (err) {
         const msg = (stderr && stderr.trim()) || err.message || 'pt-online-schema-change failed';
@@ -118,7 +152,24 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
     maxLoad,
     criticalLoad,
     alterForeignKeysMethod = 'auto',
-    ptoscPath
+    ptoscPath,
+    analyzeBeforeSwap = true,
+    checkAlter = true,
+    checkForeignKeys = true,
+    checkInterval,
+    checkPlan = true,
+    checkReplicationFilters = true,
+    checkReplicaLag = false,
+    chunkIndex,
+    chunkIndexColumns,
+    chunkSize = 1000,
+    chunkSizeLimit = 4.0,
+    chunkTime = 0.5,
+    dropNewTable = true,
+    dropOldTable = true,
+    dropTriggers = true,
+    checkUniqueKeyChange = true,
+    maxLag = 25
   } = options;
 
   if (maxLoad !== undefined && !Number.isInteger(maxLoad)) {
@@ -126,6 +177,24 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
   }
   if (criticalLoad !== undefined && !Number.isInteger(criticalLoad)) {
     throw new TypeError(`criticalLoad must be an integer, got ${typeof criticalLoad}`);
+  }
+  if (checkInterval !== undefined && !Number.isInteger(checkInterval)) {
+    throw new TypeError(`checkInterval must be an integer, got ${typeof checkInterval}`);
+  }
+  if (chunkIndexColumns !== undefined && !Number.isInteger(chunkIndexColumns)) {
+    throw new TypeError(`chunkIndexColumns must be an integer, got ${typeof chunkIndexColumns}`);
+  }
+  if (chunkSize !== undefined && !Number.isInteger(chunkSize)) {
+    throw new TypeError(`chunkSize must be an integer, got ${typeof chunkSize}`);
+  }
+  if (chunkSizeLimit !== undefined && typeof chunkSizeLimit !== 'number') {
+    throw new TypeError(`chunkSizeLimit must be a number, got ${typeof chunkSizeLimit}`);
+  }
+  if (chunkTime !== undefined && typeof chunkTime !== 'number') {
+    throw new TypeError(`chunkTime must be a number, got ${typeof chunkTime}`);
+  }
+  if (maxLag !== undefined && !Number.isInteger(maxLag)) {
+    throw new TypeError(`maxLag must be an integer, got ${typeof maxLag}`);
   }
   if (!VALID_FOREIGN_KEYS_METHODS.includes(alterForeignKeysMethod)) {
     throw new TypeError(
@@ -151,7 +220,24 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
       socketPath: conn.socketPath,
       maxLoad,
       criticalLoad,
-      dryRun: true
+      dryRun: true,
+      analyzeBeforeSwap,
+      checkAlter,
+      checkForeignKeys,
+      checkInterval,
+      checkPlan,
+      checkReplicationFilters,
+      checkReplicaLag,
+      chunkIndex,
+      chunkIndexColumns,
+      chunkSize,
+      chunkSizeLimit,
+      chunkTime,
+      dropNewTable,
+      dropOldTable,
+      dropTriggers,
+      checkUniqueKeyChange,
+      maxLag
     }),
     envPassword: usedPassword
   });
@@ -171,7 +257,24 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
       socketPath: conn.socketPath,
       maxLoad,
       criticalLoad,
-      dryRun: false
+      dryRun: false,
+      analyzeBeforeSwap,
+      checkAlter,
+      checkForeignKeys,
+      checkInterval,
+      checkPlan,
+      checkReplicationFilters,
+      checkReplicaLag,
+      chunkIndex,
+      chunkIndexColumns,
+      chunkSize,
+      chunkSizeLimit,
+      chunkTime,
+      dropNewTable,
+      dropOldTable,
+      dropTriggers,
+      checkUniqueKeyChange,
+      maxLag
     }),
     envPassword: usedPassword
   });

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -1,15 +1,33 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import * as child from 'child_process';
-import { alterTableWithPTOSC, alterTableWithBuilder } from '../index.js';
+import child from 'child_process';
+import { alterTableWithBuilder } from '../index.js';
+
+function createKnex() {
+  const qb = {
+    where: vi.fn().mockReturnThis(),
+    update: vi.fn().mockResolvedValue(1)
+  };
+  const knex = vi.fn().mockReturnValue(qb);
+  knex.client = { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } };
+  knex.raw = (sql, bindings) => ({ toQuery: () => sql });
+  knex.schema = {
+    hasTable: vi.fn().mockResolvedValue(true),
+    alterTable: vi.fn((_name, _cb) => ({
+      toSQL: () => [{ sql: 'ALTER TABLE `users` ADD COLUMN `age` INT', bindings: [] }]
+    }))
+  };
+  return knex;
+}
 
 describe('knex-ptosc-plugin', () => {
   let execFileSpy;
 
   beforeEach(() => {
-    execFileSpy = vi.spyOn(child, 'execFile').mockImplementation((cmd, args, opts, cb) => {
-      // Pretend pt-osc succeeds for both dry-run and execute
-      cb(null, 'ok', '');
-    });
+    execFileSpy = vi
+      .spyOn(child, 'execFile')
+      .mockImplementation((cmd, args, opts, cb) => {
+        cb(null, 'ok', '');
+      });
   });
 
   afterEach(() => {
@@ -17,46 +35,33 @@ describe('knex-ptosc-plugin', () => {
   });
 
   it('passes --alter as a separate arg (no shell quoting)', async () => {
-    const knex = {
-      client: { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } },
-      schema: { raw: vi.fn() }
-    };
-
-    await alterTableWithPTOSC(knex, 'users', 'ADD COLUMN `age` INT', {});
-    expect(execFileSpy).toHaveBeenCalled();
+    const knex = createKnex();
+    await alterTableWithBuilder(knex, 'users', (t) => { t.string('age'); }, {});
     const args = execFileSpy.mock.calls[0][1];
     expect(args[0]).toBe('--alter');
     expect(args[1]).toContain('ADD COLUMN `age` INT');
   });
 
   it('extracts ALTER clause from builder SQL and runs twice (dry + exec)', async () => {
-    const knex = {
-      client: { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } },
-      raw: (sql, bindings) => ({ toQuery: () => sql }), // simple passthrough for test
-      schema: {
-        hasTable: vi.fn().mockResolvedValue(true),
-        alterTable: vi.fn((_name, _cb) => ({
-          toSQL: () => [{ sql: 'ALTER TABLE `users` ADD COLUMN `age` INT', bindings: [] }]
-        }))
-      },
-      // emulate knex(...).where().update()
-      // lock table behavior
-      async schema_hasTable() { return true; },
-      async from() { return this; },
-      async where() { return this; },
-      async update() { return 1; },
-      async select() { return [{ is_locked: 0 }]; }
-    };
-
-    // Patch methods used by acquireMigrationLock
-    knex.schema.hasTable = vi.fn().mockResolvedValue(true);
-    const tableFn = vi.fn().mockReturnValue(knex);
-    knex['knex_migrations_lock'] = tableFn;
-    const q = vi.fn().mockReturnValue(1);
-    knex.update = q;
-    knex.where = vi.fn().mockReturnValue(knex);
-
+    const knex = createKnex();
     await alterTableWithBuilder(knex, 'users', (t) => { t.string('age'); }, {});
     expect(execFileSpy).toHaveBeenCalledTimes(2); // dry-run + execute
+  });
+
+  it('supports additional pt-osc flags', async () => {
+    const knex = createKnex();
+    await alterTableWithBuilder(knex, 'users', (t) => { t.string('age'); }, {
+      analyzeBeforeSwap: false,
+      checkReplicaLag: true,
+      maxLag: 10,
+      chunkSize: 2000
+    });
+    const args = execFileSpy.mock.calls[0][1];
+    expect(args).toContain('--noanalyze-before-swap');
+    expect(args).toContain('--check-replica-lag');
+    const lagIdx = args.indexOf('--max-lag');
+    expect(args[lagIdx + 1]).toBe('10');
+    const sizeIdx = args.indexOf('--chunk-size');
+    expect(args[sizeIdx + 1]).toBe('2000');
   });
 });


### PR DESCRIPTION
## Summary
- wire up many pt-online-schema-change flags such as analyzeBeforeSwap, checkPlan, and chunkSize
- document and type new options in the public PtoscOptions interface
- cover sample flags in tests
- fix `--no` flag syntax to use forms like `--nodrop-old-table`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f97b9d1f083339c763836ec2432e9