### PR TITLE
feat: add configurable logger

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ export interface PtoscOptions {
   dropTriggers?: boolean;
   checkUniqueKeyChange?: boolean;
   maxLag?: number;
+  logger?: { log: (...args: any[]) => void; error: (...args: any[]) => void };
 }
 
 /**

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -64,4 +64,13 @@ describe('knex-ptosc-plugin', () => {
     const sizeIdx = args.indexOf('--chunk-size');
     expect(args[sizeIdx + 1]).toBe('2000');
   });
+
+  it('uses a custom logger when provided', async () => {
+    const knex = createKnex();
+    const logger = { log: vi.fn(), error: vi.fn() };
+    const consoleSpy = vi.spyOn(console, 'log');
+    await alterTableWithBuilder(knex, 'users', (t) => { t.string('age'); }, { logger });
+    expect(logger.log).toHaveBeenCalled();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- add configurable logger option defaulting to console
- use logger in pt-osc helper functions
- test custom logger usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fbb7e8ec883338b8cb2955388b329