### PR TITLE
Capture pt-osc error output and support larger buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The builder version will:
 | `dropTriggers`            | `boolean`                                                  | `true`                      | `--drop-triggers` or `--nodrop-triggers`                         |
 | `checkUniqueKeyChange`    | `boolean`                                                  | `true`                      | `--check-unique-key-change` or `--nocheck-unique-key-change`     |
 | `maxLag`                  | `number`                                                   | `25`                        | Passed to `--max-lag`                                            |
+| `maxBuffer`               | `number`                                                   | `10485760`                  | `child_process.execFile` `maxBuffer` in bytes                    |
 | `migrationsTable`         | `string`                                                   | `'knex_migrations'`         | Overrides migrations table name used for lock checks             |
 | `migrationsLockTable`     | `string`                                                   | `'knex_migrations_lock'`    | Overrides migrations lock table name used when acquiring lock    |
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,12 +21,13 @@ export interface PtoscOptions {
   dropNewTable?: boolean;
   dropOldTable?: boolean;
   dropTriggers?: boolean;
-  checkUniqueKeyChange?: boolean;
-  maxLag?: number;
-  logger?: { log: (...args: any[]) => void; error: (...args: any[]) => void };
-  migrationsTable?: string;
-  migrationsLockTable?: string;
-}
+    checkUniqueKeyChange?: boolean;
+    maxLag?: number;
+    maxBuffer?: number;
+    logger?: { log: (...args: any[]) => void; error: (...args: any[]) => void };
+    migrationsTable?: string;
+    migrationsLockTable?: string;
+  }
 
 /**
  * Public API: ONLY builder-based alters (no raw SQL).


### PR DESCRIPTION
## Summary
- capture pt-osc exit code, stdout, and stderr and include them in logged errors
- allow configuring child process maxBuffer to prevent truncated output
- document new option and add tests for error handling and buffer configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a501070ff483338400c452b3e6c7fb