### PR TITLE
feat: allow custom pt-osc load metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ await alterTableWithBuilder(knex, "users", (t) => {
 });
 ```
 
+By default, load thresholds monitor the `Threads_running` metric. Use
+`maxLoadMetric` and `criticalLoadMetric` to override the metric names if
+needed.
+
 The builder version will:
 
 - Compile the Knex schema change to SQL (including bindings)
@@ -97,7 +101,9 @@ The builder version will:
 | ------------------------- | ---------------------------------------------------------- | --------------------------- | ---------------------------------------------------------------- |
 | `password`                | `string`                                                   | from Knex connection        | Override DB password; will be passed via `MYSQL_PWD` env         |
 | `maxLoad`                 | `number`                                                   | `undefined`                 | Passed to `--max-load` (e.g. `Threads_connected=150`)            |
+| `maxLoadMetric`           | `string`                                                   | `'Threads_running'`         | Metric name used in `--max-load` (e.g. `Threads_connected`)      |
 | `criticalLoad`            | `number`                                                   | `undefined`                 | Passed to `--critical-load` (e.g. `Threads_running=50`)          |
+| `criticalLoadMetric`      | `string`                                                   | `'Threads_running'`         | Metric name used in `--critical-load` (e.g. `Threads_running`)   |
 | `alterForeignKeysMethod`  | `'auto' \| 'rebuild_constraints' \| 'drop_swap' \| 'none'` | `'auto'`                    | Passed to `--alter-foreign-keys-method`                          |
 | `ptoscPath`               | `string`                                                   | `'pt-online-schema-change'` | Path to pt-osc binary                                            |
 | `analyzeBeforeSwap`       | `boolean`                                                  | `true`                      | `--analyze-before-swap` or `--noanalyze-before-swap`             |

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,9 @@ import type { Knex } from 'knex';
 export interface PtoscOptions {
   password?: string;
   maxLoad?: number;
+  maxLoadMetric?: string;
   criticalLoad?: number;
+  criticalLoadMetric?: string;
   alterForeignKeysMethod?: 'auto' | 'rebuild_constraints' | 'drop_swap' | 'none';
   ptoscPath?: string;
   analyzeBeforeSwap?: boolean;
@@ -21,13 +23,13 @@ export interface PtoscOptions {
   dropNewTable?: boolean;
   dropOldTable?: boolean;
   dropTriggers?: boolean;
-    checkUniqueKeyChange?: boolean;
-    maxLag?: number;
-    maxBuffer?: number;
-    logger?: { log: (...args: any[]) => void; error: (...args: any[]) => void };
-    migrationsTable?: string;
-    migrationsLockTable?: string;
-  }
+  checkUniqueKeyChange?: boolean;
+  maxLag?: number;
+  maxBuffer?: number;
+  logger?: { log: (...args: any[]) => void; error: (...args: any[]) => void };
+  migrationsTable?: string;
+  migrationsLockTable?: string;
+}
 
 /**
  * Public API: ONLY builder-based alters (no raw SQL).

--- a/index.js
+++ b/index.js
@@ -71,7 +71,9 @@ function buildPtoscArgs({
   port,
   socketPath,
   maxLoad,
+  maxLoadMetric = 'Threads_running',
   criticalLoad,
+  criticalLoadMetric = 'Threads_running',
   dryRun,
   analyzeBeforeSwap = true,
   checkAlter = true,
@@ -101,8 +103,8 @@ function buildPtoscArgs({
   ];
   if (port != null) args.push('--port', String(port));
   if (socketPath) args.push('--socket', socketPath);
-  if (maxLoad != null) args.push('--max-load', `Threads_running=${maxLoad}`);
-  if (criticalLoad != null) args.push('--critical-load', `Threads_running=${criticalLoad}`);
+  if (maxLoad != null) args.push('--max-load', `${maxLoadMetric}=${maxLoad}`);
+  if (criticalLoad != null) args.push('--critical-load', `${criticalLoadMetric}=${criticalLoad}`);
   args.push(analyzeBeforeSwap ? '--analyze-before-swap' : '--noanalyze-before-swap');
   args.push(checkAlter ? '--check-alter' : '--nocheck-alter');
   args.push(checkForeignKeys ? '--check-foreign-keys' : '--nocheck-foreign-keys');
@@ -166,7 +168,9 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
   const {
     password,
     maxLoad,
+    maxLoadMetric,
     criticalLoad,
+    criticalLoadMetric,
     alterForeignKeysMethod = 'auto',
     ptoscPath,
     analyzeBeforeSwap = true,
@@ -240,7 +244,9 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
       port: conn.port,
       socketPath: conn.socketPath,
       maxLoad,
+      maxLoadMetric,
       criticalLoad,
+      criticalLoadMetric,
       dryRun: true,
       analyzeBeforeSwap,
       checkAlter,
@@ -279,7 +285,9 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
       port: conn.port,
       socketPath: conn.socketPath,
       maxLoad,
+      maxLoadMetric,
       criticalLoad,
+      criticalLoadMetric,
       dryRun: false,
       analyzeBeforeSwap,
       checkAlter,

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -65,6 +65,21 @@ describe('knex-ptosc-plugin', () => {
     expect(args[sizeIdx + 1]).toBe('2000');
   });
 
+  it('passes custom load metric names', async () => {
+    const knex = createKnex();
+    await alterTableWithBuilder(knex, 'users', (t) => { t.string('age'); }, {
+      maxLoad: 100,
+      maxLoadMetric: 'Threads_connected',
+      criticalLoad: 50,
+      criticalLoadMetric: 'Threads_running'
+    });
+    const args = execFileSpy.mock.calls[0][1];
+    const maxIdx = args.indexOf('--max-load');
+    expect(args[maxIdx + 1]).toBe('Threads_connected=100');
+    const criticalIdx = args.indexOf('--critical-load');
+    expect(args[criticalIdx + 1]).toBe('Threads_running=50');
+  });
+
     it('uses a custom logger when provided', async () => {
       const knex = createKnex();
       const logger = { log: vi.fn(), error: vi.fn() };


### PR DESCRIPTION
## Summary
- add `maxLoadMetric` and `criticalLoadMetric` options defaulting to Threads_running
- pass custom metric names to pt-online-schema-change
- document new options and test custom metric usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a505041fd083338c7ae3d3c45ca067