### PR TITLE
chore: whitelist npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
     }
   },
   "types": "./index.d.ts",
+  "files": [
+    "index.js",
+    "index.cjs",
+    "index.d.ts",
+    "src/"
+  ],
   "scripts": {
     "lint": "eslint .",
     "test": "npm run lint && vitest run",


### PR DESCRIPTION
## Summary
- restrict published files to runtime sources using the `files` array

## Testing
- `npm test`
- `npm pack`
