### PR TITLE
chore: require node 16

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+This project requires [Node.js](https://nodejs.org/) version 16 or newer. Please ensure your development environment meets this requirement before installing dependencies or running tests.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   ],
   "author": "Geoff Winans <geoff.winans@brainfailures.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=16"
+  },
   "exports": {
     ".": {
       "types": "./index.d.ts",


### PR DESCRIPTION
## Summary
- require Node.js 16+ in package metadata
- note Node.js >=16 in contributing guide

## Testing
- `npm test`