### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
 # Contributing
 
 This project requires [Node.js](https://nodejs.org/) version 16 or newer. Please ensure your development environment meets this requirement before installing dependencies or running tests.
+
+## Editor configuration
+
+The repository provides an [EditorConfig](https://editorconfig.org/) configuration in the `.editorconfig` file. Enable EditorConfig support in your IDE to automatically use UTF-8 encoding, LF line endings, two-space indentation, and to trim trailing whitespace.


### PR DESCRIPTION
## Summary
- add project-wide EditorConfig with UTF-8 charset, LF line endings, 2-space indent, and trimmed whitespace
- document using EditorConfig so contributors enable matching IDE support

## Testing
- `npm test`