### PR TITLE
Rename alterTableWithBuilder to alterTableWithPtosc

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm install knex-ptosc-plugin
 Import the plugin.
 
 ```js
-import { alterTableWithBuilder } from "knex-ptosc-plugin";
+import { alterTableWithPtosc } from "knex-ptosc-plugin";
 ```
 
 ---
@@ -72,7 +72,7 @@ import { alterTableWithBuilder } from "knex-ptosc-plugin";
 Build your migration.
 
 ```js
-await alterTableWithBuilder(knex, "users", (t) => {
+await alterTableWithPtosc(knex, "users", (t) => {
   t.string("nickname").nullable();
 }, {
   maxLoad: 150,
@@ -147,10 +147,10 @@ The builder version will:
 ## Example Migration
 
 ```js
-import { alterTableWithBuilder } from "knex-ptosc-plugin";
+import { alterTableWithPtosc } from "knex-ptosc-plugin";
 
 export async function up(knex) {
-  await alterTableWithBuilder(knex, "users", (t) => {
+  await alterTableWithPtosc(knex, "users", (t) => {
     t.string("nickname").nullable();
   }, {
     maxLoad: 150,
@@ -159,7 +159,7 @@ export async function up(knex) {
 }
 
 export async function down(knex) {
-  await alterTableWithBuilder(knex, "users", (t) => {
+  await alterTableWithPtosc(knex, "users", (t) => {
     t.dropColumn("nickname");
   }, {
     maxLoad: 150,

--- a/index.cjs
+++ b/index.cjs
@@ -1,5 +1,5 @@
 'use strict';
 
 // Bridge to the ESM build; functions remain async Promises.
-module.exports.alterTableWithBuilder = (...args) =>
-  import('./index.js').then(m => m.alterTableWithBuilder(...args));
+module.exports.alterTableWithPtosc = (...args) =>
+  import('./index.js').then(m => m.alterTableWithPtosc(...args));

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,9 +33,9 @@ export interface PtoscOptions {
 }
 
 /**
- * Public API: ONLY builder-based alters (no raw SQL).
+ * Public API: builder-based alters (no raw SQL) run through pt-online-schema-change.
  */
-export declare function alterTableWithBuilder(
+export declare function alterTableWithPtosc(
   knex: Knex,
   tableName: string,
   alterCallback: (tableBuilder: Knex.AlterTableBuilder) => void,

--- a/src/index.js
+++ b/src/index.js
@@ -160,11 +160,11 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
 }
 
 /**
- * Public API: ONLY the Knex builder path.
+ * Public API: Knex builder path run through pt-online-schema-change.
  * Compiles the alterTable callback, extracts ALTER statements, applies bindings,
  * and runs each via pt-osc under the migration lock.
  */
-export async function alterTableWithBuilder(knex, tableName, alterCallback, options = {}) {
+export async function alterTableWithPtosc(knex, tableName, alterCallback, options = {}) {
   const builder = knex.schema.alterTable(tableName, alterCallback);
   const compiled = builder.toSQL();
   const stmts = Array.isArray(compiled) ? compiled : [compiled];


### PR DESCRIPTION
## Summary
- rename alterTableWithBuilder helper to alterTableWithPtosc
- document the new function name in README and examples
- adjust tests and TypeScript/CommonJS entry points

## Testing
- `npm test`