### PR TITLE
Reduce ptosc logging unless debug enabled

### DIFF
--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,4 @@
+export function isDebugEnabled() {
+  const env = process.env.DEBUG || '';
+  return env.split(/[\s,]+/).includes('knex-ptosc-plugin');
+}


### PR DESCRIPTION
## Summary
- add helper to detect DEBUG=knex-ptosc-plugin
- suppress ptosc stdout/stderr unless debug flag is set
- log table name and progress while still printing full command

## Testing
- `npm test`