### PR TITLE
feat: log pt-osc ETA with progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The builder version will:
 | `checkUniqueKeyChange`    | `boolean`                                                  | `true`                      | `--check-unique-key-change` or `--nocheck-unique-key-change`     |
 | `maxLag`                  | `number`                                                   | `25`                        | Passed to `--max-lag`                                            |
 | `maxBuffer`               | `number`                                                   | `10485760`                  | `child_process.execFile` `maxBuffer` in bytes                    |
-| `onProgress`              | `(pct: number) => void`                                    | `undefined`                 | Callback for progress percentage parsed from output               |
+| `onProgress`              | `(pct: number) => void`                                    | `undefined`                 | Callback for progress percentage parsed from output; logs include pt-osc ETA when available |
 | `migrationsTable`         | `string`                                                   | `'knex_migrations'`         | Overrides migrations table name used for lock checks             |
 | `migrationsLockTable`     | `string`                                                   | `'knex_migrations_lock'`    | Overrides migrations lock table name used when acquiring lock    |
 

--- a/src/index.js
+++ b/src/index.js
@@ -120,14 +120,13 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
     envPassword: usedPassword,
     logger,
     maxBuffer,
-    onProgress,
+    onProgress: onProgress ? (pct) => onProgress(pct) : undefined,
     printCommand: debug
   });
 
   if (debug) {
     logger.log(`[PT-OSC] Dry-run successful. Executing ALTER TABLE ${table} ${alterClause}`);
   }
-
   await runPtoscProcess({
     ptoscPath,
     args: buildPtoscArgs({
@@ -165,9 +164,12 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
     envPassword: usedPassword,
     logger,
     maxBuffer,
-    onProgress: (pct) => {
+    onProgress: (pct, eta) => {
       if (onProgress) onProgress(pct);
-      if (!debug) logger.log(`[PT-OSC] ${pct}%`);
+      if (!debug) {
+        const msg = eta ? `[PT-OSC] ${pct}% ETA: ${eta}` : `[PT-OSC] ${pct}%`;
+        logger.log(msg);
+      }
     },
     printCommand: true
   });

--- a/src/ptosc-runner.js
+++ b/src/ptosc-runner.js
@@ -113,7 +113,7 @@ export async function runPtoscProcess({
     let stdout = '';
     let stderr = '';
     let total = 0;
-    const pctRegex = /\b(\d{1,3}(?:\.\d+)?)%/;
+    const progressRegex = /\b(\d{1,3}(?:\.\d+)?)%(?:\s+(\d+:\d+(?::\d+)?)\s+remain)?/;
     let stdoutLine = '';
     let stderrLine = '';
 
@@ -135,8 +135,8 @@ export async function runPtoscProcess({
         split.forEach(line => {
           if (!line) return;
           if (debug) logger.error(line);
-          const m = line.match(pctRegex);
-          if (m && onProgress) onProgress(parseFloat(m[1]));
+          const m = line.match(progressRegex);
+          if (m && onProgress) onProgress(parseFloat(m[1]), m[2]);
         });
         stderr += str;
       } else {
@@ -144,8 +144,8 @@ export async function runPtoscProcess({
         split.forEach(line => {
           if (!line) return;
           if (debug) logger.log(line);
-          const m = line.match(pctRegex);
-          if (m && onProgress) onProgress(parseFloat(m[1]));
+          const m = line.match(progressRegex);
+          if (m && onProgress) onProgress(parseFloat(m[1]), m[2]);
         });
         stdout += str;
       }
@@ -166,13 +166,13 @@ export async function runPtoscProcess({
     child.on('close', (code) => {
       if (stdoutLine) {
         if (debug) logger.log(stdoutLine);
-        const m = stdoutLine.match(pctRegex);
-        if (m && onProgress) onProgress(parseFloat(m[1]));
+        const m = stdoutLine.match(progressRegex);
+        if (m && onProgress) onProgress(parseFloat(m[1]), m[2]);
       }
       if (stderrLine) {
         if (debug) logger.error(stderrLine);
-        const m = stderrLine.match(pctRegex);
-        if (m && onProgress) onProgress(parseFloat(m[1]));
+        const m = stderrLine.match(progressRegex);
+        if (m && onProgress) onProgress(parseFloat(m[1]), m[2]);
       }
       if (code) {
         logger.error(`pt-online-schema-change failed with code ${code}`);


### PR DESCRIPTION
## Summary
- parse ETA from pt-online-schema-change output
- log pt-osc ETA when available and expose percentage to `onProgress`
- cover progress logging with and without ETA

## Testing
- `npm test`