### PR TITLE
log pt-osc statistics when enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The builder version will:
 | `maxBuffer`               | `number`                                                   | `10485760`                  | `child_process.execFile` `maxBuffer` in bytes                    |
 | `logger`                  | `{ log: Function, error: Function }`                       | `console`                   | Override default logging methods                                    |
 | `onProgress`              | `(pct: number) => void`                                    | `undefined`                 | Callback for progress percentage parsed from output; logs include pt-osc ETA when available |
-| `statistics`              | `boolean`                                                  | `false`                     | Adds `--statistics`; collect internal pt-osc counters            |
+| `statistics`              | `boolean`                                                  | `false`                     | Adds `--statistics`; log and collect internal pt-osc counters   |
 | `onStatistics`            | `(stats: Record<string, number>) => void`                  | `undefined`                 | Invoked with parsed statistics object when `statistics` is true |
 | `migrationsTable`         | `string`                                                   | `'knex_migrations'`         | Overrides migrations table name used for lock checks             |
 | `migrationsLockTable`     | `string`                                                   | `'knex_migrations_lock'`    | Overrides migrations lock table name used when acquiring lock    |
@@ -139,7 +139,7 @@ The builder version will:
 
 ### Statistics example
 
-When `statistics: true`, pt-online-schema-change prints internal counters at the end of the run. These are parsed into an object and returned (or sent to `onStatistics`). Example output:
+When `statistics: true`, pt-online-schema-change prints internal counters at the end of the run. These are parsed into an object, logged via the provided logger, and returned (or sent to `onStatistics`). Example output:
 
 ```
 # Event          Count

--- a/src/ptosc-runner.js
+++ b/src/ptosc-runner.js
@@ -194,7 +194,15 @@ export async function runPtoscProcess({
         }
       });
       const statsCopy = { ...stats };
-      if (onStatistics && Object.keys(statsCopy).length) onStatistics(statsCopy);
+      const hasStats = Object.keys(statsCopy).length > 0;
+      if (hasStats) {
+        logger.log(
+          `[PT-OSC] Statistics: ${Object.entries(statsCopy)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(', ')}`
+        );
+        if (onStatistics) onStatistics(statsCopy);
+      }
       resolve({ stdout, stderr, statistics: statsCopy });
     });
   });

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -265,6 +265,7 @@ describe('knex-ptosc-plugin', () => {
   it('parses statistics output and invokes callback', async () => {
     const knex = createKnex();
     const onStats = vi.fn();
+    const logger = { log: vi.fn(), error: vi.fn() };
 
     // Dry run
     spawnSpy.mockImplementationOnce(() => {
@@ -300,11 +301,12 @@ describe('knex-ptosc-plugin', () => {
       return proc;
     });
 
-    const result = await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { statistics: true, onStatistics: onStats });
+    const result = await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { statistics: true, onStatistics: onStats, logger });
 
     const args = spawnSpy.mock.calls[0][1];
     expect(args).toContain('--statistics');
     expect(onStats).toHaveBeenCalledWith({ inserts: 5, updates: 2 });
+    expect(logger.log).toHaveBeenCalledWith('[PT-OSC] Statistics: inserts=5, updates=2');
     expect(result).toEqual([{ inserts: 5, updates: 2 }]);
   });
 


### PR DESCRIPTION
## Summary
- log pt-online-schema-change statistics when the `statistics` option is enabled
- document that statistics are logged in addition to being returned
- test statistics logging

## Testing
- `npm test`