### PR TITLE
Add CI workflow with integration test app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: test
+          MYSQL_DATABASE: ptosc
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -ptest"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install MySQL client and pt-online-schema-change
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mysql-client percona-toolkit
+      - name: Wait for MySQL
+        run: |
+          for i in {1..30}; do
+            mysql -h 127.0.0.1 -uroot -ptest -e "SELECT 1" && break
+            sleep 1
+          done
+      - name: Install dependencies
+        run: npm ci
+      - name: Run unit tests
+        run: npm test
+      - name: Run test application
+        env:
+          DB_HOST: 127.0.0.1
+          DB_USER: root
+          DB_PASSWORD: test
+          DB_NAME: ptosc
+        run: |
+          git clone https://github.com/gwinans/kpp-test-app
+          cd kpp-test-app
+          npm install
+          npm install ../ --no-save
+          npm run migrate
+          npm run rollback

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ DEBUG=knex-ptosc-plugin npm run migrate
 
 Without `DEBUG`, only high-level progress percentages are logged.
 
+## Testing
+
+Run `npm test` to execute linting and unit tests. Continuous integration also clones the [kpp-test-app](https://github.com/gwinans/kpp-test-app) and runs its migrations against a MySQL instance (`root`/`test`, database `ptosc`) to verify end-to-end behavior.
+
 ---
 
 ## Safety & Security


### PR DESCRIPTION
## Summary
- run lint, unit tests, and kpp-test-app migrations in GitHub Actions with MySQL
- document how tests run

## Testing
- `npm test`
