### PR TITLE
Fixes workflow not running because dumb dev.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - '*.md'
       - '**/*.md'
-      - '.github'
+      - '.github/**'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Fixes workflows not running - was using `paths:` instead of `paths-ignore:`.

Yes, I am an idiot. Don't tell anyone.
