### PR TITLE
Drop pt-online-schema-change --version from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
           DB_NAME: ptosc
           DEBUG: knex-ptosc-plugin
         run: |
-          pt-online-schema-change --version
           git clone https://github.com/gwinans/kpp-test-app
           cd kpp-test-app
           npm install


### PR DESCRIPTION
## Summary

* Drops `pt-online-schema-change --version` from workflow.
