### PR TITLE
feat: attempt instant alter before ptosc

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Github Repo: https://github.com/gwinans/knex-ptosc-plugin
   `.alterTable()` builder syntax.
 - **Respects Knex bindings**: Correctly interpolates values from `.toSQL()`
   output.
+- **Instant alters when possible**: Attempts native `ALTER TABLE ... ALGORITHM=INSTANT, LOCK=NONE` and falls back to pt-osc when unsupported.
 
+Servers running MySQL 5.6 or 5.7 skip the instant-alter attempt and always use pt-online-schema-change. Set `forcePtosc: true` to force the pt-osc path on newer versions as well.
 ---
 
 ## Requirements
@@ -70,6 +72,7 @@ npm install knex-ptosc-plugin
 | `criticalLoadMetric`      | `string`                                                   | `'Threads_running'`         | Metric name used in `--critical-load` (e.g. `Threads_running`)                              |
 | `alterForeignKeysMethod`  | `'auto' \| 'rebuild_constraints' \| 'drop_swap' \| 'none'` | `'auto'`                    | Passed to `--alter-foreign-keys-method`                                                     |
 | `ptoscPath`               | `string`                                                   | `'pt-online-schema-change'` | Path to pt-osc binary                                                                       |
+| `forcePtosc`              | `boolean`                                                  | `false`                     | Skip the instant-alter attempt and always run pt-osc                                |
 | `analyzeBeforeSwap`       | `boolean`                                                  | `true`                      | `--analyze-before-swap` or `--noanalyze-before-swap`                                        |
 | `checkAlter`              | `boolean`                                                  | `true`                      | `--check-alter` or `--nocheck-alter`                                                        |
 | `checkForeignKeys`        | `boolean`                                                  | `true`                      | `--check-foreign-keys` or `--nocheck-foreign-keys`                                          |

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export interface PtoscOptions {
   criticalLoadMetric?: string;
   alterForeignKeysMethod?: 'auto' | 'rebuild_constraints' | 'drop_swap' | 'none';
   ptoscPath?: string;
+  forcePtosc?: boolean;
   analyzeBeforeSwap?: boolean;
   checkAlter?: boolean;
   checkForeignKeys?: boolean;

--- a/test/native.test.js
+++ b/test/native.test.js
@@ -63,7 +63,7 @@ describe('native instant alter', () => {
     const knex = createKnex(rawImpl);
     await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {});
     expect(rawImpl).toHaveBeenCalledWith(
-      expect.stringContaining('ALTER TABLE users ADD COLUMN `age` INT, ALGORITHM=INSTANT')
+      expect.stringContaining('ALTER TABLE users ADD COLUMN `age` INT, ALGORITHM=INSTANT, LOCK=NONE')
     );
     expect(spawnSpy).not.toHaveBeenCalled();
   });

--- a/test/native.test.js
+++ b/test/native.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import child from 'child_process';
+import { PassThrough } from 'stream';
+import { EventEmitter } from 'events';
+import { alterTableWithPtosc } from '../index.js';
+
+function createKnex(rawImpl) {
+  const qb = {
+    where: vi.fn().mockReturnThis(),
+    update: vi.fn().mockResolvedValue(1),
+    select: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue({ is_locked: 0 })
+  };
+  const knex = vi.fn().mockReturnValue(qb);
+  knex.client = { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } };
+  knex.raw = vi.fn((sql, bindings) => {
+    if (bindings) return { toQuery: () => sql };
+    return rawImpl(sql);
+  });
+  knex.schema = {
+    hasTable: vi.fn().mockResolvedValue(true),
+    alterTable: vi.fn((_name, _cb) => ({
+      toSQL: () => [{ sql: 'ALTER TABLE `users` ADD COLUMN `age` INT', bindings: [] }]
+    }))
+  };
+  return knex;
+}
+
+describe('native instant alter', () => {
+  let spawnSpy;
+  let spawnSyncSpy;
+
+  beforeEach(() => {
+    spawnSyncSpy = vi
+      .spyOn(child, 'spawnSync')
+      .mockReturnValue({ status: 0, stdout: Buffer.from('/usr/bin/pt-online-schema-change\n') });
+    spawnSpy = vi.spyOn(child, 'spawn').mockImplementation(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'ok');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 0);
+      });
+      return proc;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses native alter when supported', async () => {
+    const rawImpl = vi.fn((sql) => {
+      if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '8.0.0' }]);
+      if (/ALTER TABLE/i.test(sql)) return Promise.resolve();
+      throw new Error('unexpected sql');
+    });
+    const knex = createKnex(rawImpl);
+    await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {});
+    expect(rawImpl).toHaveBeenCalledWith(
+      expect.stringContaining('ALTER TABLE users ADD COLUMN `age` INT, ALGORITHM=INSTANT, LOCK=NONE')
+    );
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to ptosc on unsupported instant alter', async () => {
+    const rawImpl = vi.fn((sql) => {
+      if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '8.0.0' }]);
+      if (/ALTER TABLE/i.test(sql)) {
+        const err = new Error('unsupported ALGORITHM=INSTANT');
+        err.errno = 1846;
+        return Promise.reject(err);
+      }
+      throw new Error('unexpected sql');
+    });
+    const knex = createKnex(rawImpl);
+    await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {});
+    expect(spawnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips native alter on MySQL 5.7', async () => {
+    const rawImpl = vi.fn((sql) => {
+      if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '5.7.42' }]);
+      if (/ALTER TABLE/i.test(sql)) throw new Error('should not reach native alter');
+      return Promise.resolve();
+    });
+    const knex = createKnex(rawImpl);
+    await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {});
+    expect(rawImpl).toHaveBeenCalledTimes(1);
+    expect(spawnSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/native.test.js
+++ b/test/native.test.js
@@ -63,7 +63,7 @@ describe('native instant alter', () => {
     const knex = createKnex(rawImpl);
     await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {});
     expect(rawImpl).toHaveBeenCalledWith(
-      expect.stringContaining('ALTER TABLE users ADD COLUMN `age` INT, ALGORITHM=INSTANT, LOCK=NONE')
+      expect.stringContaining('ALTER TABLE users ADD COLUMN `age` INT, ALGORITHM=INSTANT')
     );
     expect(spawnSpy).not.toHaveBeenCalled();
   });

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -14,7 +14,11 @@ function createKnex(updateMock) {
   };
   const knex = vi.fn().mockReturnValue(qb);
   knex.client = { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } };
-  knex.raw = (sql, bindings) => ({ toQuery: () => sql });
+  knex.raw = vi.fn((sql, bindings) => {
+    if (bindings) return { toQuery: () => sql };
+    if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '5.7.42' }]);
+    throw new Error('unexpected sql');
+  });
   knex.schema = {
     hasTable: vi.fn().mockResolvedValue(true),
     alterTable: vi.fn((_name, _cb) => ({


### PR DESCRIPTION
## Summary
- attempt native `ALTER TABLE ... ALGORITHM=INSTANT, LOCK=NONE` before invoking pt-online-schema-change
- add `forcePtosc` option and document instant alter behaviour
- cover native alter success, fallback, and MySQL 5.7 behaviour in tests

## Testing
- `npm test`