### PR TITLE
feat: attempt instant alter before ptosc

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Github Repo: https://github.com/gwinans/knex-ptosc-plugin
   `.alterTable()` builder syntax.
 - **Respects Knex bindings**: Correctly interpolates values from `.toSQL()`
   output.
+- **Instant alters when possible**: Attempts native `ALTER TABLE ... ALGORITHM=INSTANT` and falls back to pt-osc when unsupported.
 
+Servers running MySQL 5.6 or 5.7 skip the instant-alter attempt and always use pt-online-schema-change. Set `forcePtosc: true` to force the pt-osc path on newer versions as well.
 ---
 
 ## Requirements
@@ -70,6 +72,7 @@ npm install knex-ptosc-plugin
 | `criticalLoadMetric`      | `string`                                                   | `'Threads_running'`         | Metric name used in `--critical-load` (e.g. `Threads_running`)                              |
 | `alterForeignKeysMethod`  | `'auto' \| 'rebuild_constraints' \| 'drop_swap' \| 'none'` | `'auto'`                    | Passed to `--alter-foreign-keys-method`                                                     |
 | `ptoscPath`               | `string`                                                   | `'pt-online-schema-change'` | Path to pt-osc binary                                                                       |
+| `forcePtosc`              | `boolean`                                                  | `false`                     | Skip the instant-alter attempt and always run pt-osc                                |
 | `analyzeBeforeSwap`       | `boolean`                                                  | `true`                      | `--analyze-before-swap` or `--noanalyze-before-swap`                                        |
 | `checkAlter`              | `boolean`                                                  | `true`                      | `--check-alter` or `--nocheck-alter`                                                        |
 | `checkForeignKeys`        | `boolean`                                                  | `true`                      | `--check-foreign-keys` or `--nocheck-foreign-keys`                                          |

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export interface PtoscOptions {
   criticalLoadMetric?: string;
   alterForeignKeysMethod?: 'auto' | 'rebuild_constraints' | 'drop_swap' | 'none';
   ptoscPath?: string;
+  forcePtosc?: boolean;
   analyzeBeforeSwap?: boolean;
   checkAlter?: boolean;
   checkForeignKeys?: boolean;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,22 @@ import { isDebugEnabled } from './debug.js';
 
 const VALID_FOREIGN_KEYS_METHODS = ['auto', 'rebuild_constraints', 'drop_swap', 'none'];
 
+const versionCache = new WeakMap();
+
+async function getMysqlVersion(knex) {
+  if (!versionCache.has(knex)) {
+    const res = await knex.raw('SELECT VERSION() AS version');
+    const row = Array.isArray(res) ? res[0] : res;
+    const ver = Array.isArray(row) ? row[0].version : row.version;
+    const m = /(\d+)\.(\d+)/.exec(ver);
+    versionCache.set(knex, {
+      major: m ? Number(m[1]) : 0,
+      minor: m ? Number(m[2]) : 0
+    });
+  }
+  return versionCache.get(knex);
+}
+
 /**
  * INTERNAL ONLY: run pt-osc for one ALTER clause (no CREATE handling here).
  * Not exported to avoid any public raw-SQL entrypoint.
@@ -181,6 +197,31 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
   return statistics ? stats : undefined;
 }
 
+async function runAlterClause(knex, table, alterClause, options = {}) {
+  const { forcePtosc } = options;
+  if (!forcePtosc) {
+    const { major, minor } = await getMysqlVersion(knex);
+    if (!(major === 5 && (minor === 6 || minor === 7))) {
+      const sql = `ALTER TABLE ${table} ${alterClause}, ALGORITHM=INSTANT`;
+      try {
+        await knex.raw(sql);
+        return;
+      } catch (err) {
+        const msg = err.message || '';
+        if (
+          err.errno === 1846 ||
+          err.errno === 1847 ||
+          (/ALGORITHM=INSTANT/i.test(msg) && /unsupported|not supported/i.test(msg))
+        ) {
+          return await runAlterClauseWithPtosc(knex, table, alterClause, options);
+        }
+        throw err;
+      }
+    }
+  }
+  return await runAlterClauseWithPtosc(knex, table, alterClause, options);
+}
+
 /**
  * Public API: Knex builder path run through pt-online-schema-change.
  * Compiles the alterTable callback, extracts ALTER statements, applies bindings,
@@ -217,7 +258,7 @@ export async function alterTableWithPtosc(knex, tableName, alterCallback, option
       // Extract the clause after: ALTER TABLE <name> <CLAUSE>
       const m = fullAlter.match(/^ALTER\s+TABLE\s+(`?(?:[^`.\s]+`?\.)?`?[^`\s]+`?)\s+(.*)$/i);
       const clause = m ? m[2] : fullAlter.replace(/^ALTER\s+TABLE\s+\S+\s+/i, '');
-      const s = await runAlterClauseWithPtosc(knex, tableName, clause, options);
+      const s = await runAlterClause(knex, tableName, clause, options);
       if (s) stats.push(s);
     }
   } finally {

--- a/test/native.test.js
+++ b/test/native.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import child from 'child_process';
+import { PassThrough } from 'stream';
+import { EventEmitter } from 'events';
+import { alterTableWithPtosc } from '../index.js';
+
+function createKnex(rawImpl) {
+  const qb = {
+    where: vi.fn().mockReturnThis(),
+    update: vi.fn().mockResolvedValue(1),
+    select: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue({ is_locked: 0 })
+  };
+  const knex = vi.fn().mockReturnValue(qb);
+  knex.client = { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } };
+  knex.raw = vi.fn((sql, bindings) => {
+    if (bindings) return { toQuery: () => sql };
+    return rawImpl(sql);
+  });
+  knex.schema = {
+    hasTable: vi.fn().mockResolvedValue(true),
+    alterTable: vi.fn((_name, _cb) => ({
+      toSQL: () => [{ sql: 'ALTER TABLE `users` ADD COLUMN `age` INT', bindings: [] }]
+    }))
+  };
+  return knex;
+}
+
+describe('native instant alter', () => {
+  let spawnSpy;
+  let spawnSyncSpy;
+
+  beforeEach(() => {
+    spawnSyncSpy = vi
+      .spyOn(child, 'spawnSync')
+      .mockReturnValue({ status: 0, stdout: Buffer.from('/usr/bin/pt-online-schema-change\n') });
+    spawnSpy = vi.spyOn(child, 'spawn').mockImplementation(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'ok');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 0);
+      });
+      return proc;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses native alter when supported', async () => {
+    const rawImpl = vi.fn((sql) => {
+      if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '8.0.0' }]);
+      if (/ALTER TABLE/i.test(sql)) return Promise.resolve();
+      throw new Error('unexpected sql');
+    });
+    const knex = createKnex(rawImpl);
+    await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {});
+    expect(rawImpl).toHaveBeenCalledWith(
+      expect.stringContaining('ALTER TABLE users ADD COLUMN `age` INT, ALGORITHM=INSTANT')
+    );
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to ptosc on unsupported instant alter', async () => {
+    const rawImpl = vi.fn((sql) => {
+      if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '8.0.0' }]);
+      if (/ALTER TABLE/i.test(sql)) {
+        const err = new Error('unsupported ALGORITHM=INSTANT');
+        err.errno = 1846;
+        return Promise.reject(err);
+      }
+      throw new Error('unexpected sql');
+    });
+    const knex = createKnex(rawImpl);
+    await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {});
+    expect(spawnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips native alter on MySQL 5.7', async () => {
+    const rawImpl = vi.fn((sql) => {
+      if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '5.7.42' }]);
+      if (/ALTER TABLE/i.test(sql)) throw new Error('should not reach native alter');
+      return Promise.resolve();
+    });
+    const knex = createKnex(rawImpl);
+    await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {});
+    expect(rawImpl).toHaveBeenCalledTimes(1);
+    expect(spawnSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -14,7 +14,11 @@ function createKnex(updateMock) {
   };
   const knex = vi.fn().mockReturnValue(qb);
   knex.client = { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } };
-  knex.raw = (sql, bindings) => ({ toQuery: () => sql });
+  knex.raw = vi.fn((sql, bindings) => {
+    if (bindings) return { toQuery: () => sql };
+    if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '5.7.42' }]);
+    throw new Error('unexpected sql');
+  });
   knex.schema = {
     hasTable: vi.fn().mockResolvedValue(true),
     alterTable: vi.fn((_name, _cb) => ({


### PR DESCRIPTION
## Summary
- attempt native `ALTER TABLE ... ALGORITHM=INSTANT` before invoking pt-online-schema-change
- add `forcePtosc` option and document instant alter behaviour
- cover native alter success, fallback, and MySQL 5.7 behaviour in tests

## Testing
- `npm test`