### PR TITLE
feat: handle rename column migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Github Repo: https://github.com/gwinans/knex-ptosc-plugin
   `.alterTable()` builder syntax.
 - **Respects Knex bindings**: Correctly interpolates values from `.toSQL()`
   output.
+- **Column rename support**: Automatically looks up column metadata for
+  `renameColumn` migrations so pt-osc can build the needed `CHANGE` clause.
 - **Instant alters when possible**: Attempts native `ALTER TABLE ... ALGORITHM=INSTANT` and falls back to pt-osc when unsupported.
 
 Servers running MySQL 5.6 or 5.7 skip the instant-alter attempt and always use pt-online-schema-change. Set `forcePtosc: true` to force the pt-osc path on newer versions as well.

--- a/src/index.js
+++ b/src/index.js
@@ -239,10 +239,49 @@ export async function alterTableWithPtosc(knex, tableName, alterCallback, option
     return knex.raw(sql, bindings).toQuery();
   });
 
-  // Only keep ALTER TABLE statements
-  const alterStatements = sqls
-    .map(sql => String(sql).trim())
-    .filter(sql => /^ALTER\s+TABLE\b/i.test(sql));
+  // Only keep ALTER TABLE statements and detect SHOW FULL FIELDS queries
+  const alterStatements = [];
+  let sawShowFull = false;
+  for (const rawSql of sqls) {
+    const sql = String(rawSql).trim();
+    if (/^ALTER\s+TABLE\b/i.test(sql)) {
+      alterStatements.push(sql);
+    } else if (/^SHOW\s+FULL\s+FIELDS\s+FROM\b/i.test(sql)) {
+      sawShowFull = true;
+    }
+  }
+
+  if (sawShowFull) {
+    const renames = builder._statements?.filter(
+      s => s.grouping === 'alterTable' && s.method === 'renameColumn'
+    ) || [];
+    for (const { args: [from, to] } of renames) {
+      const res = await knex.raw('SHOW FULL FIELDS FROM ?? WHERE Field = ?', [tableName, from]);
+      let rows = Array.isArray(res) ? res[0] : res;
+      const column = Array.isArray(rows) ? rows[0] : rows;
+      if (!column) {
+        throw new Error(`Unable to retrieve column info for ${from}`);
+      }
+      const wrap = v => `\`${String(v).replace(/`/g, '``')}\``;
+      const tableWrapped = /`/.test(tableName) ? tableName : wrap(tableName);
+      let sql = `ALTER TABLE ${tableWrapped} CHANGE ${wrap(from)} ${wrap(to)} ${column.Type}`;
+      if (String(column.Null).toUpperCase() !== 'YES') {
+        sql += ' NOT NULL';
+      } else {
+        sql += ' NULL';
+      }
+      if (column.Default !== undefined && column.Default !== null) {
+        sql += ` DEFAULT '${column.Default}'`;
+      }
+      if (column.Collation !== undefined && column.Collation !== null) {
+        sql += ` COLLATE '${column.Collation}'`;
+      }
+      if (column.Extra === 'auto_increment') {
+        sql += ' AUTO_INCREMENT';
+      }
+      alterStatements.push(sql);
+    }
+  }
 
   if (alterStatements.length === 0) {
     throw new Error(

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -28,6 +28,56 @@ function createKnex(updateMock) {
   return knex;
 }
 
+function createRenameKnex() {
+  const qb = {
+    where: vi.fn().mockReturnThis(),
+    update: vi.fn().mockResolvedValue(1),
+    select: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue({ is_locked: 0 })
+  };
+  const knex = vi.fn().mockReturnValue(qb);
+  knex.client = { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } };
+  knex.raw = vi.fn((sql, bindings) => {
+    if (bindings) {
+      if (/SHOW FULL FIELDS FROM `users` where field = \?/i.test(sql)) {
+        return { toQuery: () => `SHOW FULL FIELDS FROM \`users\` where field = '${bindings[0]}'` };
+      }
+      if (/SHOW FULL FIELDS FROM \?\? WHERE Field = \?/i.test(sql)) {
+        return Promise.resolve([
+          {
+            Field: 'name',
+            Type: 'varchar(255)',
+            Null: 'YES',
+            Default: null,
+            Collation: 'utf8mb4_unicode_ci',
+            Extra: ''
+          }
+        ]);
+      }
+      return { toQuery: () => sql };
+    }
+    if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '5.7.42' }]);
+    throw new Error('unexpected sql');
+  });
+  knex.schema = {
+    hasTable: vi.fn().mockResolvedValue(true),
+    alterTable: vi.fn((_name, cb) => {
+      const builder = {
+        _statements: [],
+        renameColumn(from, to) {
+          this._statements.push({ grouping: 'alterTable', method: 'renameColumn', args: [from, to] });
+        },
+        toSQL() {
+          return [{ sql: 'SHOW FULL FIELDS FROM `users` where field = ?', bindings: ['name'] }];
+        }
+      };
+      cb(builder);
+      return builder;
+    })
+  };
+  return knex;
+}
+
 describe('knex-ptosc-plugin', () => {
   let spawnSpy;
   let spawnSyncSpy;
@@ -98,6 +148,14 @@ describe('knex-ptosc-plugin', () => {
     expect(args[maxIdx + 1]).toBe('Threads_connected=100');
     const criticalIdx = args.indexOf('--critical-load');
     expect(args[criticalIdx + 1]).toBe('Threads_running=50');
+  });
+
+  it('constructs CHANGE clause for renameColumn migrations', async () => {
+    const knex = createRenameKnex();
+    await alterTableWithPtosc(knex, 'users', (t) => { t.renameColumn('name', 'full_name'); }, {});
+    const args = spawnSpy.mock.calls[0][1];
+    expect(args[1]).toContain('CHANGE `name` `full_name` varchar(255)');
+    expect(spawnSpy).toHaveBeenCalledTimes(2);
   });
 
     it('uses a custom logger when provided', async () => {


### PR DESCRIPTION
## Summary
- support column renames by querying metadata when schema builder emits `SHOW FULL FIELDS`
- document rename support
- test rename column migrations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7e1fbd58883339910f637c7e28cf6