### PR TITLE
feat: handle rename column migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Github Repo: https://github.com/gwinans/knex-ptosc-plugin
   `.alterTable()` builder syntax.
 - **Respects Knex bindings**: Correctly interpolates values from `.toSQL()`
   output.
+- **Column rename support**: Automatically looks up column metadata for
+  `renameColumn` migrations so pt-osc can build the needed `CHANGE` clause.
 - **Instant alters when possible**: Attempts native `ALTER TABLE ... ALGORITHM=INSTANT` and falls back to pt-osc when unsupported.
 
 Servers running MySQL 5.6 or 5.7 skip the instant-alter attempt and always use pt-online-schema-change. Set `forcePtosc: true` to force the pt-osc path on newer versions as well.

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,12 @@ import { acquireMigrationLock } from './lock.js';
 import { buildPtoscArgs, runPtoscProcess } from './ptosc-runner.js';
 import { isDebugEnabled } from './debug.js';
 
-const VALID_FOREIGN_KEYS_METHODS = ['auto', 'rebuild_constraints', 'drop_swap', 'none'];
+const VALID_FOREIGN_KEYS_METHODS = [
+  'auto',
+  'rebuild_constraints',
+  'drop_swap',
+  'none',
+];
 
 const versionCache = new WeakMap();
 
@@ -14,7 +19,7 @@ async function getMysqlVersion(knex) {
     const m = /(\d+)\.(\d+)/.exec(ver);
     versionCache.set(knex, {
       major: m ? Number(m[1]) : 0,
-      minor: m ? Number(m[2]) : 0
+      minor: m ? Number(m[2]) : 0,
     });
   }
   return versionCache.get(knex);
@@ -54,39 +59,74 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
     logger = console,
     onProgress,
     statistics = false,
-    onStatistics
+    onStatistics,
   } = options;
 
   if (maxLoad !== undefined && (!Number.isInteger(maxLoad) || maxLoad <= 0)) {
     throw new TypeError(`maxLoad must be a positive integer, got ${maxLoad}`);
   }
-  if (criticalLoad !== undefined && (!Number.isInteger(criticalLoad) || criticalLoad <= 0)) {
-    throw new TypeError(`criticalLoad must be a positive integer, got ${criticalLoad}`);
+  if (
+    criticalLoad !== undefined &&
+    (!Number.isInteger(criticalLoad) || criticalLoad <= 0)
+  ) {
+    throw new TypeError(
+      `criticalLoad must be a positive integer, got ${criticalLoad}`,
+    );
   }
-  if (checkInterval !== undefined && (!Number.isInteger(checkInterval) || checkInterval <= 0)) {
-    throw new TypeError(`checkInterval must be a positive integer, got ${checkInterval}`);
+  if (
+    checkInterval !== undefined &&
+    (!Number.isInteger(checkInterval) || checkInterval <= 0)
+  ) {
+    throw new TypeError(
+      `checkInterval must be a positive integer, got ${checkInterval}`,
+    );
   }
-  if (chunkIndexColumns !== undefined && (!Number.isInteger(chunkIndexColumns) || chunkIndexColumns <= 0)) {
-    throw new TypeError(`chunkIndexColumns must be a positive integer, got ${chunkIndexColumns}`);
+  if (
+    chunkIndexColumns !== undefined &&
+    (!Number.isInteger(chunkIndexColumns) || chunkIndexColumns <= 0)
+  ) {
+    throw new TypeError(
+      `chunkIndexColumns must be a positive integer, got ${chunkIndexColumns}`,
+    );
   }
-  if (chunkSize !== undefined && (!Number.isInteger(chunkSize) || chunkSize <= 0)) {
-    throw new TypeError(`chunkSize must be a positive integer, got ${chunkSize}`);
+  if (
+    chunkSize !== undefined &&
+    (!Number.isInteger(chunkSize) || chunkSize <= 0)
+  ) {
+    throw new TypeError(
+      `chunkSize must be a positive integer, got ${chunkSize}`,
+    );
   }
-  if (chunkSizeLimit !== undefined && (typeof chunkSizeLimit !== 'number' || chunkSizeLimit <= 0)) {
-    throw new TypeError(`chunkSizeLimit must be a positive number, got ${chunkSizeLimit}`);
+  if (
+    chunkSizeLimit !== undefined &&
+    (typeof chunkSizeLimit !== 'number' || chunkSizeLimit <= 0)
+  ) {
+    throw new TypeError(
+      `chunkSizeLimit must be a positive number, got ${chunkSizeLimit}`,
+    );
   }
-  if (chunkTime !== undefined && (typeof chunkTime !== 'number' || chunkTime <= 0)) {
-    throw new TypeError(`chunkTime must be a positive number, got ${chunkTime}`);
+  if (
+    chunkTime !== undefined &&
+    (typeof chunkTime !== 'number' || chunkTime <= 0)
+  ) {
+    throw new TypeError(
+      `chunkTime must be a positive number, got ${chunkTime}`,
+    );
   }
   if (maxLag !== undefined && (!Number.isInteger(maxLag) || maxLag <= 0)) {
     throw new TypeError(`maxLag must be a positive integer, got ${maxLag}`);
   }
-  if (maxBuffer !== undefined && (!Number.isInteger(maxBuffer) || maxBuffer <= 0)) {
-    throw new TypeError(`maxBuffer must be a positive integer, got ${maxBuffer}`);
+  if (
+    maxBuffer !== undefined &&
+    (!Number.isInteger(maxBuffer) || maxBuffer <= 0)
+  ) {
+    throw new TypeError(
+      `maxBuffer must be a positive integer, got ${maxBuffer}`,
+    );
   }
   if (!VALID_FOREIGN_KEYS_METHODS.includes(alterForeignKeysMethod)) {
     throw new TypeError(
-      `alterForeignKeysMethod must be one of ${VALID_FOREIGN_KEYS_METHODS.join(', ')}; got '${alterForeignKeysMethod}'.`
+      `alterForeignKeysMethod must be one of ${VALID_FOREIGN_KEYS_METHODS.join(', ')}; got '${alterForeignKeysMethod}'.`,
     );
   }
 
@@ -134,17 +174,19 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
       dropTriggers,
       checkUniqueKeyChange,
       maxLag,
-      statistics
+      statistics,
     }),
     envPassword: usedPassword,
     logger,
     maxBuffer,
     onProgress: onProgress ? (pct) => onProgress(pct) : undefined,
-    printCommand: debug
+    printCommand: debug,
   });
 
   if (debug) {
-    logger.log(`[PT-OSC] Dry-run successful. Executing ALTER TABLE ${table} ${alterClause}`);
+    logger.log(
+      `[PT-OSC] Dry-run successful. Executing ALTER TABLE ${table} ${alterClause}`,
+    );
   }
   const { statistics: stats } = await runPtoscProcess({
     ptoscPath,
@@ -179,7 +221,7 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
       dropTriggers,
       checkUniqueKeyChange,
       maxLag,
-      statistics
+      statistics,
     }),
     envPassword: usedPassword,
     logger,
@@ -192,7 +234,7 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
       }
     },
     onStatistics,
-    printCommand: true
+    printCommand: true,
   });
   return statistics ? stats : undefined;
 }
@@ -211,9 +253,15 @@ async function runAlterClause(knex, table, alterClause, options = {}) {
         if (
           err.errno === 1846 ||
           err.errno === 1847 ||
-          (/ALGORITHM=INSTANT/i.test(msg) && /unsupported|not supported/i.test(msg))
+          (/ALGORITHM=INSTANT/i.test(msg) &&
+            /unsupported|not supported/i.test(msg))
         ) {
-          return await runAlterClauseWithPtosc(knex, table, alterClause, options);
+          return await runAlterClauseWithPtosc(
+            knex,
+            table,
+            alterClause,
+            options,
+          );
         }
         throw err;
       }
@@ -227,27 +275,85 @@ async function runAlterClause(knex, table, alterClause, options = {}) {
  * Compiles the alterTable callback, extracts ALTER statements, applies bindings,
  * and runs each via pt-osc under the migration lock..
  */
-export async function alterTableWithPtosc(knex, tableName, alterCallback, options = {}) {
+export async function alterTableWithPtosc(
+  knex,
+  tableName,
+  alterCallback,
+  options = {},
+) {
   const builder = knex.schema.alterTable(tableName, alterCallback);
+
+  // Capture renameColumn calls before compilation, as toSQL() may clear _statements
+  const renameOps =
+    builder._statements
+      ?.filter(
+        (s) => s.grouping === 'alterTable' && s.method === 'renameColumn',
+      )
+      .map(({ args }) => args) || [];
+
   const compiled = builder.toSQL();
   const stmts = Array.isArray(compiled) ? compiled : [compiled];
 
   // Resolve bindings into full SQL strings
-  const sqls = stmts.map(s => {
+  const sqls = stmts.map((s) => {
     const sql = s.sql ?? s;
     const bindings = s.bindings ?? [];
     return knex.raw(sql, bindings).toQuery();
   });
 
   // Only keep ALTER TABLE statements
-  const alterStatements = sqls
-    .map(sql => String(sql).trim())
-    .filter(sql => /^ALTER\s+TABLE\b/i.test(sql));
+  const alterStatements = [];
+  for (const rawSql of sqls) {
+    const sql = String(rawSql).trim();
+    if (/^ALTER\s+TABLE\b/i.test(sql)) {
+      alterStatements.push(sql);
+    }
+  }
+
+  for (const [from, to] of renameOps) {
+    // Skip if an ALTER ... CHANGE for this column already exists
+    const exists = alterStatements.some((sql) => {
+      const re = new RegExp(
+        '\\bCHANGE\\s+`' + from.replace(/`/g, '``') + '`\\b',
+        'i',
+      );
+      return re.test(sql);
+    });
+    if (exists) continue;
+
+    const res = await knex.raw('SHOW FULL FIELDS FROM ?? WHERE Field = ?', [
+      tableName,
+      from,
+    ]);
+    let rows = Array.isArray(res) ? res[0] : res;
+    const column = Array.isArray(rows) ? rows[0] : rows;
+    if (!column) {
+      throw new Error(`Unable to retrieve column info for ${from}`);
+    }
+    const wrap = (v) => `\`${String(v).replace(/`/g, '``')}\``;
+    const tableWrapped = /`/.test(tableName) ? tableName : wrap(tableName);
+    let sql = `ALTER TABLE ${tableWrapped} CHANGE ${wrap(from)} ${wrap(to)} ${column.Type}`;
+    if (String(column.Null).toUpperCase() !== 'YES') {
+      sql += ' NOT NULL';
+    } else {
+      sql += ' NULL';
+    }
+    if (column.Default !== undefined && column.Default !== null) {
+      sql += ` DEFAULT '${column.Default}'`;
+    }
+    if (column.Collation !== undefined && column.Collation !== null) {
+      sql += ` COLLATE '${column.Collation}'`;
+    }
+    if (column.Extra === 'auto_increment') {
+      sql += ' AUTO_INCREMENT';
+    }
+    alterStatements.push(sql);
+  }
 
   if (alterStatements.length === 0) {
     throw new Error(
       `No ALTER TABLE statements generated for "${tableName}". ` +
-      `Only ALTER operations are supported. Use knex.schema.createTable(...) to create tables.`
+        `Only ALTER operations are supported. Use knex.schema.createTable(...) to create tables.`,
     );
   }
 
@@ -256,8 +362,12 @@ export async function alterTableWithPtosc(knex, tableName, alterCallback, option
   try {
     for (const fullAlter of alterStatements) {
       // Extract the clause after: ALTER TABLE <name> <CLAUSE>
-      const m = fullAlter.match(/^ALTER\s+TABLE\s+(`?(?:[^`.\s]+`?\.)?`?[^`\s]+`?)\s+(.*)$/i);
-      const clause = m ? m[2] : fullAlter.replace(/^ALTER\s+TABLE\s+\S+\s+/i, '');
+      const m = fullAlter.match(
+        /^ALTER\s+TABLE\s+(`?(?:[^`.\s]+`?\.)?`?[^`\s]+`?)\s+(.*)$/i,
+      );
+      const clause = m
+        ? m[2]
+        : fullAlter.replace(/^ALTER\s+TABLE\s+\S+\s+/i, '');
       const s = await runAlterClause(knex, tableName, clause, options);
       if (s) stats.push(s);
     }

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -10,20 +10,92 @@ function createKnex(updateMock) {
     where: vi.fn().mockReturnThis(),
     update: updateMock || vi.fn().mockResolvedValue(1),
     select: vi.fn().mockReturnThis(),
-    first: vi.fn().mockResolvedValue({ is_locked: 0 })
+    first: vi.fn().mockResolvedValue({ is_locked: 0 }),
   };
   const knex = vi.fn().mockReturnValue(qb);
-  knex.client = { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } };
+  knex.client = {
+    config: { connection: { database: 'db', host: 'localhost', user: 'root' } },
+  };
   knex.raw = vi.fn((sql, bindings) => {
     if (bindings) return { toQuery: () => sql };
-    if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '5.7.42' }]);
+    if (/SELECT VERSION/i.test(sql))
+      return Promise.resolve([{ version: '5.7.42' }]);
     throw new Error('unexpected sql');
   });
   knex.schema = {
     hasTable: vi.fn().mockResolvedValue(true),
     alterTable: vi.fn((_name, _cb) => ({
-      toSQL: () => [{ sql: 'ALTER TABLE `users` ADD COLUMN `age` INT', bindings: [] }]
-    }))
+      toSQL: () => [
+        { sql: 'ALTER TABLE `users` ADD COLUMN `age` INT', bindings: [] },
+      ],
+    })),
+  };
+  return knex;
+}
+
+function createRenameKnex() {
+  const qb = {
+    where: vi.fn().mockReturnThis(),
+    update: vi.fn().mockResolvedValue(1),
+    select: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue({ is_locked: 0 }),
+  };
+  const knex = vi.fn().mockReturnValue(qb);
+  knex.client = {
+    config: { connection: { database: 'db', host: 'localhost', user: 'root' } },
+  };
+  knex.raw = vi.fn((sql, bindings) => {
+    if (bindings) {
+      if (/SHOW FULL FIELDS FROM `users` where field = \?/i.test(sql)) {
+        return {
+          toQuery: () =>
+            `SHOW FULL FIELDS FROM \`users\` where field = '${bindings[0]}'`,
+        };
+      }
+      if (/SHOW FULL FIELDS FROM \?\? WHERE Field = \?/i.test(sql)) {
+        return Promise.resolve([
+          {
+            Field: 'name',
+            Type: 'varchar(255)',
+            Null: 'YES',
+            Default: null,
+            Collation: 'utf8mb4_unicode_ci',
+            Extra: '',
+          },
+        ]);
+      }
+      return { toQuery: () => sql };
+    }
+    if (/SELECT VERSION/i.test(sql))
+      return Promise.resolve([{ version: '5.7.42' }]);
+    throw new Error('unexpected sql');
+  });
+  knex.schema = {
+    hasTable: vi.fn().mockResolvedValue(true),
+    alterTable: vi.fn((_name, cb) => {
+      const builder = {
+        _statements: [],
+        renameColumn(from, to) {
+          this._statements.push({
+            grouping: 'alterTable',
+            method: 'renameColumn',
+            args: [from, to],
+          });
+        },
+        toSQL() {
+          const out = [
+            {
+              sql: 'SHOW FULL FIELDS FROM `users` where field = ?',
+              bindings: ['name'],
+            },
+          ];
+          this._statements = [];
+          return out;
+        },
+      };
+      cb(builder);
+      return builder;
+    }),
   };
   return knex;
 }
@@ -33,7 +105,12 @@ describe('knex-ptosc-plugin', () => {
   let spawnSyncSpy;
 
   beforeEach(() => {
-    spawnSyncSpy = vi.spyOn(child, 'spawnSync').mockReturnValue({ status: 0, stdout: Buffer.from('/usr/bin/pt-online-schema-change\n') });
+    spawnSyncSpy = vi
+      .spyOn(child, 'spawnSync')
+      .mockReturnValue({
+        status: 0,
+        stdout: Buffer.from('/usr/bin/pt-online-schema-change\n'),
+      });
     spawnSpy = vi.spyOn(child, 'spawn').mockImplementation(() => {
       const stdout = new PassThrough();
       const stderr = new PassThrough();
@@ -56,7 +133,14 @@ describe('knex-ptosc-plugin', () => {
 
   it('passes --alter as a separate arg (no shell quoting)', async () => {
     const knex = createKnex();
-    await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {});
+    await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.string('age');
+      },
+      {},
+    );
     const args = spawnSpy.mock.calls[0][1];
     expect(args[0]).toBe('--alter');
     expect(args[1]).toContain('ADD COLUMN `age` INT');
@@ -64,18 +148,32 @@ describe('knex-ptosc-plugin', () => {
 
   it('extracts ALTER clause from builder SQL and runs twice (dry + exec)', async () => {
     const knex = createKnex();
-    await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {});
+    await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.string('age');
+      },
+      {},
+    );
     expect(spawnSpy).toHaveBeenCalledTimes(2); // dry-run + execute
   });
 
   it('supports additional pt-osc flags', async () => {
     const knex = createKnex();
-    await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {
-      analyzeBeforeSwap: false,
-      checkReplicaLag: true,
-      maxLag: 10,
-      chunkSize: 2000
-    });
+    await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.string('age');
+      },
+      {
+        analyzeBeforeSwap: false,
+        checkReplicaLag: true,
+        maxLag: 10,
+        chunkSize: 2000,
+      },
+    );
     const args = spawnSpy.mock.calls[0][1];
     expect(args).toContain('--noanalyze-before-swap');
     expect(args).toContain('--check-replica-lag');
@@ -87,12 +185,19 @@ describe('knex-ptosc-plugin', () => {
 
   it('passes custom load metric names', async () => {
     const knex = createKnex();
-    await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {
-      maxLoad: 100,
-      maxLoadMetric: 'Threads_connected',
-      criticalLoad: 50,
-      criticalLoadMetric: 'Threads_running'
-    });
+    await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.string('age');
+      },
+      {
+        maxLoad: 100,
+        maxLoadMetric: 'Threads_connected',
+        criticalLoad: 50,
+        criticalLoadMetric: 'Threads_running',
+      },
+    );
     const args = spawnSpy.mock.calls[0][1];
     const maxIdx = args.indexOf('--max-load');
     expect(args[maxIdx + 1]).toBe('Threads_connected=100');
@@ -100,226 +205,326 @@ describe('knex-ptosc-plugin', () => {
     expect(args[criticalIdx + 1]).toBe('Threads_running=50');
   });
 
-    it('uses a custom logger when provided', async () => {
-      const knex = createKnex();
-      const logger = { log: vi.fn(), error: vi.fn() };
-      const consoleSpy = vi.spyOn(console, 'log');
-      await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { logger });
-      expect(logger.log).toHaveBeenCalled();
-      expect(consoleSpy).not.toHaveBeenCalled();
-    });
+  it('constructs CHANGE clause for renameColumn migrations', async () => {
+    const knex = createRenameKnex();
+    await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.renameColumn('name', 'full_name');
+      },
+      {},
+    );
+    const args = spawnSpy.mock.calls[0][1];
+    expect(args[1]).toContain('CHANGE `name` `full_name` varchar(255)');
+    expect(spawnSpy).toHaveBeenCalledTimes(2);
+  });
 
-    it('surfaces pt-osc errors with code and output', async () => {
-      const knex = createKnex();
-      spawnSpy.mockImplementationOnce(() => {
-        const stdout = new PassThrough();
-        const stderr = new PassThrough();
-        const proc = new EventEmitter();
-        proc.stdout = stdout;
-        proc.stderr = stderr;
-        setImmediate(() => {
-          stdout.emit('data', 'out');
-          stderr.emit('data', 'err');
-          stdout.end();
-          stderr.end();
-          proc.emit('close', 42);
-        });
-        return proc;
+  it('uses a custom logger when provided', async () => {
+    const knex = createKnex();
+    const logger = { log: vi.fn(), error: vi.fn() };
+    const consoleSpy = vi.spyOn(console, 'log');
+    await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.string('age');
+      },
+      { logger },
+    );
+    expect(logger.log).toHaveBeenCalled();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces pt-osc errors with code and output', async () => {
+    const knex = createKnex();
+    spawnSpy.mockImplementationOnce(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'out');
+        stderr.emit('data', 'err');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 42);
       });
-      await expect(
-        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, {})
-      ).rejects.toMatchObject({ code: 42, stdout: 'out', stderr: 'err' });
+      return proc;
     });
+    await expect(
+      alterTableWithPtosc(
+        knex,
+        'users',
+        (t) => {
+          t.string('age');
+        },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 42, stdout: 'out', stderr: 'err' });
+  });
 
-    it('logs full pt-osc output when the command fails', async () => {
-      const knex = createKnex();
-      const logger = { log: vi.fn(), error: vi.fn() };
-      spawnSpy.mockImplementationOnce(() => {
-        const stdout = new PassThrough();
-        const stderr = new PassThrough();
-        const proc = new EventEmitter();
-        proc.stdout = stdout;
-        proc.stderr = stderr;
-        setImmediate(() => {
-          stdout.emit('data', 'out-line\n');
-          stderr.emit('data', 'err-line\n');
-          stdout.end();
-          stderr.end();
-          proc.emit('close', 1);
-        });
-        return proc;
+  it('logs full pt-osc output when the command fails', async () => {
+    const knex = createKnex();
+    const logger = { log: vi.fn(), error: vi.fn() };
+    spawnSpy.mockImplementationOnce(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'out-line\n');
+        stderr.emit('data', 'err-line\n');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 1);
       });
-      await expect(
-        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { logger })
-      ).rejects.toThrow();
-      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('out-line'));
-      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('err-line'));
+      return proc;
     });
+    await expect(
+      alterTableWithPtosc(
+        knex,
+        'users',
+        (t) => {
+          t.string('age');
+        },
+        { logger },
+      ),
+    ).rejects.toThrow();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('out-line'),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('err-line'),
+    );
+  });
 
-    it('includes trailing output without newline when the command fails', async () => {
-      const knex = createKnex();
-      const logger = { log: vi.fn(), error: vi.fn() };
-      spawnSpy.mockImplementationOnce(() => {
-        const stdout = new PassThrough();
-        const stderr = new PassThrough();
-        const proc = new EventEmitter();
-        proc.stdout = stdout;
-        proc.stderr = stderr;
-        setImmediate(() => {
-          stdout.emit('data', 'out1\n');
-          stdout.emit('data', 'out2');
-          stderr.emit('data', 'err1\n');
-          stderr.emit('data', 'err2');
-          stdout.end();
-          stderr.end();
-          proc.emit('close', 1);
-        });
-        return proc;
+  it('includes trailing output without newline when the command fails', async () => {
+    const knex = createKnex();
+    const logger = { log: vi.fn(), error: vi.fn() };
+    spawnSpy.mockImplementationOnce(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'out1\n');
+        stdout.emit('data', 'out2');
+        stderr.emit('data', 'err1\n');
+        stderr.emit('data', 'err2');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 1);
       });
-      const prev = process.env.DEBUG;
-      process.env.DEBUG = 'knex-ptosc-plugin';
-      await expect(
-        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { logger })
-      ).rejects.toThrow();
-      process.env.DEBUG = prev;
-      const stdoutCall = logger.error.mock.calls.find(c => c[0].startsWith('[PT-OSC] stdout:'));
-      expect(stdoutCall[0]).toContain('out1\nout2');
-      const stderrCall = logger.error.mock.calls.find(c => c[0].startsWith('[PT-OSC] stderr:'));
-      expect(stderrCall[0]).toContain('err1\nerr2');
+      return proc;
     });
+    const prev = process.env.DEBUG;
+    process.env.DEBUG = 'knex-ptosc-plugin';
+    await expect(
+      alterTableWithPtosc(
+        knex,
+        'users',
+        (t) => {
+          t.string('age');
+        },
+        { logger },
+      ),
+    ).rejects.toThrow();
+    process.env.DEBUG = prev;
+    const stdoutCall = logger.error.mock.calls.find((c) =>
+      c[0].startsWith('[PT-OSC] stdout:'),
+    );
+    expect(stdoutCall[0]).toContain('out1\nout2');
+    const stderrCall = logger.error.mock.calls.find((c) =>
+      c[0].startsWith('[PT-OSC] stderr:'),
+    );
+    expect(stderrCall[0]).toContain('err1\nerr2');
+  });
 
-    it('passes maxBuffer to spawn', async () => {
-      const knex = createKnex();
-      await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { maxBuffer: 1024 });
-      expect(spawnSpy.mock.calls[0][2].maxBuffer).toBe(1024);
-    });
+  it('passes maxBuffer to spawn', async () => {
+    const knex = createKnex();
+    await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.string('age');
+      },
+      { maxBuffer: 1024 },
+    );
+    expect(spawnSpy.mock.calls[0][2].maxBuffer).toBe(1024);
+  });
 
-    it('rejects when chunkSize is non-positive', async () => {
-      const knex = createKnex();
-      await expect(
-        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { chunkSize: 0 })
-      ).rejects.toThrow(/chunkSize must be a positive integer/);
-      expect(spawnSpy).not.toHaveBeenCalled();
-    });
+  it('rejects when chunkSize is non-positive', async () => {
+    const knex = createKnex();
+    await expect(
+      alterTableWithPtosc(
+        knex,
+        'users',
+        (t) => {
+          t.string('age');
+        },
+        { chunkSize: 0 },
+      ),
+    ).rejects.toThrow(/chunkSize must be a positive integer/);
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
 
-    it('rejects when maxLoad is non-positive', async () => {
-      const knex = createKnex();
-      await expect(
-        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { maxLoad: -1 })
-      ).rejects.toThrow(/maxLoad must be a positive integer/);
-      expect(spawnSpy).not.toHaveBeenCalled();
-    });
+  it('rejects when maxLoad is non-positive', async () => {
+    const knex = createKnex();
+    await expect(
+      alterTableWithPtosc(
+        knex,
+        'users',
+        (t) => {
+          t.string('age');
+        },
+        { maxLoad: -1 },
+      ),
+    ).rejects.toThrow(/maxLoad must be a positive integer/);
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
 
-    it('rejects unsupported alterForeignKeysMethod', async () => {
-      const knex = createKnex();
-      await expect(
-        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { alterForeignKeysMethod: 'invalid' })
-      ).rejects.toThrow(/alterForeignKeysMethod must be one of/);
-      expect(spawnSpy).not.toHaveBeenCalled();
-    });
+  it('rejects unsupported alterForeignKeysMethod', async () => {
+    const knex = createKnex();
+    await expect(
+      alterTableWithPtosc(
+        knex,
+        'users',
+        (t) => {
+          t.string('age');
+        },
+        { alterForeignKeysMethod: 'invalid' },
+      ),
+    ).rejects.toThrow(/alterForeignKeysMethod must be one of/);
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
 
-    it('emits progress updates', async () => {
-      const knex = createKnex();
-      const onProgress = vi.fn();
-      spawnSpy.mockImplementationOnce(() => {
-        const stdout = new PassThrough();
-        const stderr = new PassThrough();
-        const proc = new EventEmitter();
-        proc.stdout = stdout;
-        proc.stderr = stderr;
-        setImmediate(() => {
-          stdout.emit('data', 'Processing 12.5% complete');
-          stdout.end();
-          stderr.end();
-          proc.emit('close', 0);
-        });
-        return proc;
+  it('emits progress updates', async () => {
+    const knex = createKnex();
+    const onProgress = vi.fn();
+    spawnSpy.mockImplementationOnce(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'Processing 12.5% complete');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 0);
       });
-      await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { onProgress });
-      expect(onProgress).toHaveBeenCalledWith(12.5);
+      return proc;
+    });
+    await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.string('age');
+      },
+      { onProgress },
+    );
+    expect(onProgress).toHaveBeenCalledWith(12.5);
+  });
+
+  it('logs ETA with progress updates', async () => {
+    const knex = createKnex();
+    const logger = { log: vi.fn(), error: vi.fn() };
+
+    // Dry run
+    spawnSpy.mockImplementationOnce(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 0);
+      });
+      return proc;
     });
 
-    it('logs ETA with progress updates', async () => {
-      const knex = createKnex();
-      const logger = { log: vi.fn(), error: vi.fn() };
-
-      // Dry run
-      spawnSpy.mockImplementationOnce(() => {
-        const stdout = new PassThrough();
-        const stderr = new PassThrough();
-        const proc = new EventEmitter();
-        proc.stdout = stdout;
-        proc.stderr = stderr;
-        setImmediate(() => {
-          stdout.end();
-          stderr.end();
-          proc.emit('close', 0);
-        });
-        return proc;
+    // Execution with progress including ETA
+    spawnSpy.mockImplementationOnce(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'Progress: 50% 00:01 remain\n');
+        stdout.emit('data', 'Progress: 100% 00:00 remain\n');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 0);
       });
-
-      // Execution with progress including ETA
-      spawnSpy.mockImplementationOnce(() => {
-        const stdout = new PassThrough();
-        const stderr = new PassThrough();
-        const proc = new EventEmitter();
-        proc.stdout = stdout;
-        proc.stderr = stderr;
-        setImmediate(() => {
-          stdout.emit('data', 'Progress: 50% 00:01 remain\n');
-          stdout.emit('data', 'Progress: 100% 00:00 remain\n');
-          stdout.end();
-          stderr.end();
-          proc.emit('close', 0);
-        });
-        return proc;
-      });
-
-      await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { logger });
-
-      expect(logger.log).toHaveBeenCalledWith('[PT-OSC] 50% ETA: 00:01');
-      expect(logger.log).toHaveBeenCalledWith('[PT-OSC] 100% ETA: 00:00');
+      return proc;
     });
 
-    it('logs progress without ETA when not provided', async () => {
-      const knex = createKnex();
-      const logger = { log: vi.fn(), error: vi.fn() };
+    await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.string('age');
+      },
+      { logger },
+    );
 
-      // Dry run
-      spawnSpy.mockImplementationOnce(() => {
-        const stdout = new PassThrough();
-        const stderr = new PassThrough();
-        const proc = new EventEmitter();
-        proc.stdout = stdout;
-        proc.stderr = stderr;
-        setImmediate(() => {
-          stdout.end();
-          stderr.end();
-          proc.emit('close', 0);
-        });
-        return proc;
+    expect(logger.log).toHaveBeenCalledWith('[PT-OSC] 50% ETA: 00:01');
+    expect(logger.log).toHaveBeenCalledWith('[PT-OSC] 100% ETA: 00:00');
+  });
+
+  it('logs progress without ETA when not provided', async () => {
+    const knex = createKnex();
+    const logger = { log: vi.fn(), error: vi.fn() };
+
+    // Dry run
+    spawnSpy.mockImplementationOnce(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 0);
       });
+      return proc;
+    });
 
-      // Execution with progress but no ETA
-      spawnSpy.mockImplementationOnce(() => {
-        const stdout = new PassThrough();
-        const stderr = new PassThrough();
-        const proc = new EventEmitter();
-        proc.stdout = stdout;
-        proc.stderr = stderr;
-        setImmediate(() => {
-          stdout.emit('data', 'Progress: 50%\n');
-          stdout.emit('data', 'Progress: 100%\n');
-          stdout.end();
-          stderr.end();
-          proc.emit('close', 0);
-        });
-        return proc;
+    // Execution with progress but no ETA
+    spawnSpy.mockImplementationOnce(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'Progress: 50%\n');
+        stdout.emit('data', 'Progress: 100%\n');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 0);
       });
+      return proc;
+    });
 
-      await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { logger });
+    await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.string('age');
+      },
+      { logger },
+    );
 
-      expect(logger.log).toHaveBeenCalledWith('[PT-OSC] 50%');
+    expect(logger.log).toHaveBeenCalledWith('[PT-OSC] 50%');
     expect(logger.log).toHaveBeenCalledWith('[PT-OSC] 100%');
   });
 
@@ -362,74 +567,104 @@ describe('knex-ptosc-plugin', () => {
       return proc;
     });
 
-    const result = await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { statistics: true, onStatistics: onStats, logger });
+    const result = await alterTableWithPtosc(
+      knex,
+      'users',
+      (t) => {
+        t.string('age');
+      },
+      { statistics: true, onStatistics: onStats, logger },
+    );
 
     const args = spawnSpy.mock.calls[0][1];
     expect(args).toContain('--statistics');
     expect(onStats).toHaveBeenCalledWith({ inserts: 5, updates: 2 });
-    expect(logger.log).toHaveBeenCalledWith('[PT-OSC] Statistics: inserts=5, updates=2');
+    expect(logger.log).toHaveBeenCalledWith(
+      '[PT-OSC] Statistics: inserts=5, updates=2',
+    );
     expect(result).toEqual([{ inserts: 5, updates: 2 }]);
   });
 
-    it('throws a descriptive error when pt-online-schema-change is missing', async () => {
-      const knex = createKnex();
-      spawnSyncSpy.mockImplementation(() => ({ status: 1, stdout: Buffer.from(''), stderr: Buffer.from('') }));
-      await expect(
-        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { ptoscPath: 'pt-online-schema-change-missing' })
-      ).rejects.toThrow('pt-online-schema-change binary not found');
-      expect(spawnSpy).not.toHaveBeenCalled();
-    });
-
-    it('logs and rethrows errors when releasing the lock', async () => {
-      const releaseError = new Error('release failed');
-      const updateMock = vi
-        .fn()
-        .mockResolvedValueOnce(1)
-        .mockRejectedValueOnce(releaseError);
-      const knex = createKnex(updateMock);
-      const logger = { log: vi.fn(), error: vi.fn() };
-      await expect(
-        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { logger })
-      ).rejects.toThrow('release failed');
-      expect(logger.error).toHaveBeenCalled();
-    });
-
-    it('treats an existing lock as acquired and release is a no-op', async () => {
-      const updateMock = vi.fn().mockResolvedValue(0);
-      const qb = {
-        where: vi.fn().mockReturnThis(),
-        update: updateMock,
-        select: vi.fn().mockReturnThis(),
-        first: vi.fn().mockResolvedValue({ is_locked: 1 })
-      };
-      const knex = vi.fn().mockReturnValue(qb);
-      knex.schema = { hasTable: vi.fn().mockResolvedValue(true) };
-
-      const lock = await acquireMigrationLock(knex);
-      await lock.release();
-
-      expect(updateMock).toHaveBeenCalledTimes(1);
-      expect(qb.select).toHaveBeenCalledWith('is_locked');
-    });
-
-    it('throws when migration tables are missing', async () => {
-      const knex = createKnex();
-      knex.schema.hasTable.mockResolvedValue(false);
-      await expect(acquireMigrationLock(knex)).rejects.toThrow(
-        /Required Knex migration tables do not exist/
-      );
-    });
-
-    it('times out if the lock cannot be acquired', async () => {
-      vi.useFakeTimers();
-      const updateMock = vi.fn().mockResolvedValue(0);
-      const knex = createKnex(updateMock);
-      const promise = acquireMigrationLock(knex, { timeoutMs: 1000, intervalMs: 100 });
-      const expectPromise = expect(promise).rejects.toThrow(
-        /Timeout acquiring knex_migrations_lock/
-      );
-      await vi.advanceTimersByTimeAsync(1100);
-      await expectPromise;
-      vi.useRealTimers();
-    });
+  it('throws a descriptive error when pt-online-schema-change is missing', async () => {
+    const knex = createKnex();
+    spawnSyncSpy.mockImplementation(() => ({
+      status: 1,
+      stdout: Buffer.from(''),
+      stderr: Buffer.from(''),
+    }));
+    await expect(
+      alterTableWithPtosc(
+        knex,
+        'users',
+        (t) => {
+          t.string('age');
+        },
+        { ptoscPath: 'pt-online-schema-change-missing' },
+      ),
+    ).rejects.toThrow('pt-online-schema-change binary not found');
+    expect(spawnSpy).not.toHaveBeenCalled();
   });
+
+  it('logs and rethrows errors when releasing the lock', async () => {
+    const releaseError = new Error('release failed');
+    const updateMock = vi
+      .fn()
+      .mockResolvedValueOnce(1)
+      .mockRejectedValueOnce(releaseError);
+    const knex = createKnex(updateMock);
+    const logger = { log: vi.fn(), error: vi.fn() };
+    await expect(
+      alterTableWithPtosc(
+        knex,
+        'users',
+        (t) => {
+          t.string('age');
+        },
+        { logger },
+      ),
+    ).rejects.toThrow('release failed');
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('treats an existing lock as acquired and release is a no-op', async () => {
+    const updateMock = vi.fn().mockResolvedValue(0);
+    const qb = {
+      where: vi.fn().mockReturnThis(),
+      update: updateMock,
+      select: vi.fn().mockReturnThis(),
+      first: vi.fn().mockResolvedValue({ is_locked: 1 }),
+    };
+    const knex = vi.fn().mockReturnValue(qb);
+    knex.schema = { hasTable: vi.fn().mockResolvedValue(true) };
+
+    const lock = await acquireMigrationLock(knex);
+    await lock.release();
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(qb.select).toHaveBeenCalledWith('is_locked');
+  });
+
+  it('throws when migration tables are missing', async () => {
+    const knex = createKnex();
+    knex.schema.hasTable.mockResolvedValue(false);
+    await expect(acquireMigrationLock(knex)).rejects.toThrow(
+      /Required Knex migration tables do not exist/,
+    );
+  });
+
+  it('times out if the lock cannot be acquired', async () => {
+    vi.useFakeTimers();
+    const updateMock = vi.fn().mockResolvedValue(0);
+    const knex = createKnex(updateMock);
+    const promise = acquireMigrationLock(knex, {
+      timeoutMs: 1000,
+      intervalMs: 100,
+    });
+    const expectPromise = expect(promise).rejects.toThrow(
+      /Timeout acquiring knex_migrations_lock/,
+    );
+    await vi.advanceTimersByTimeAsync(1100);
+    await expectPromise;
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- support column renames by querying metadata when schema builder emits `SHOW FULL FIELDS`
- document rename support
- test rename column migrations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7e1fbd58883339910f637c7e28cf6