### PR TITLE
Skip pt-osc for index operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Github Repo: https://github.com/gwinans/knex-ptosc-plugin
 - **Respects Knex bindings**: Correctly interpolates values from `.toSQL()`
   output.
 - **Instant alters when possible**: Attempts native `ALTER TABLE ... ALGORITHM=INSTANT` and falls back to pt-osc when unsupported.
+- **Native index operations**: `ADD INDEX` and `DROP INDEX` statements run directly via Knex without pt-osc.
 
 Servers running MySQL 5.6 or 5.7 skip the instant-alter attempt and always use pt-online-schema-change. Set `forcePtosc: true` to force the pt-osc path on newer versions as well.
 ---

--- a/src/index.js
+++ b/src/index.js
@@ -258,6 +258,13 @@ export async function alterTableWithPtosc(knex, tableName, alterCallback, option
       // Extract the clause after: ALTER TABLE <name> <CLAUSE>
       const m = fullAlter.match(/^ALTER\s+TABLE\s+(`?(?:[^`.\s]+`?\.)?`?[^`\s]+`?)\s+(.*)$/i);
       const clause = m ? m[2] : fullAlter.replace(/^ALTER\s+TABLE\s+\S+\s+/i, '');
+
+      // If the clause only adds or drops indexes, run it natively via Knex.
+      if (/\b(ADD|DROP)\s+(?:UNIQUE\s+)?(?:INDEX|KEY)\b/i.test(clause)) {
+        await knex.raw(fullAlter);
+        continue;
+      }
+
       const s = await runAlterClause(knex, tableName, clause, options);
       if (s) stats.push(s);
     }

--- a/test/index-ops.test.js
+++ b/test/index-ops.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import child from 'child_process';
+import { PassThrough } from 'stream';
+import { EventEmitter } from 'events';
+import { alterTableWithPtosc } from '../index.js';
+
+function createKnex(alterSql) {
+  const qb = {
+    where: vi.fn().mockReturnThis(),
+    update: vi.fn().mockResolvedValue(1),
+    select: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue({ is_locked: 0 })
+  };
+  const knex = vi.fn().mockReturnValue(qb);
+  knex.client = { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } };
+  knex.raw = vi.fn((sql, bindings) => {
+    if (bindings) return { toQuery: () => sql };
+    if (sql === alterSql) return Promise.resolve();
+    throw new Error('unexpected sql');
+  });
+  knex.schema = {
+    hasTable: vi.fn().mockResolvedValue(true),
+    alterTable: vi.fn((_name, _cb) => ({
+      toSQL: () => [{ sql: alterSql, bindings: [] }]
+    }))
+  };
+  return knex;
+}
+
+describe('index operations bypass ptosc', () => {
+  let spawnSpy;
+  let spawnSyncSpy;
+
+  beforeEach(() => {
+    spawnSpy = vi.spyOn(child, 'spawn').mockImplementation(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'ok');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 0);
+      });
+      return proc;
+    });
+    spawnSyncSpy = vi
+      .spyOn(child, 'spawnSync')
+      .mockReturnValue({ status: 0, stdout: Buffer.from('/usr/bin/pt-online-schema-change\n') });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('runs ADD INDEX natively', async () => {
+    const sql = 'ALTER TABLE `users` ADD INDEX `idx_age` (`age`)';
+    const knex = createKnex(sql);
+    await alterTableWithPtosc(knex, 'users', () => {}, {});
+    expect(knex.raw).toHaveBeenCalledWith(sql);
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(spawnSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it('runs DROP INDEX natively', async () => {
+    const sql = 'ALTER TABLE `users` DROP INDEX `idx_age`';
+    const knex = createKnex(sql);
+    await alterTableWithPtosc(knex, 'users', () => {}, {});
+    expect(knex.raw).toHaveBeenCalledWith(sql);
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(spawnSyncSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Run `ADD INDEX` and `DROP INDEX` statements using Knex instead of pt-online-schema-change
- Document native handling for index operations
- Test to ensure index statements bypass pt-osc

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7e988ba648333907279d10f999a75