### PR TITLE
feat: add ptosc minimum rows option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 2025-08-24 - 0.2.6:
+
+- Added `ptoscMinRows` option to run native `ALTER TABLE` when table rows are below a threshold.
+
 ### 2025-08-23 - 0.2.5:
 
 - Pass pt-osc ETA through the `onProgress` callback.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ npm install knex-ptosc-plugin
 | `alterForeignKeysMethod`  | `'auto' \| 'rebuild_constraints' \| 'drop_swap' \| 'none'` | `'auto'`                    | Passed to `--alter-foreign-keys-method`                                                     |
 | `ptoscPath`               | `string`                                                   | `'pt-online-schema-change'` | Path to pt-osc binary                                                                       |
 | `forcePtosc`              | `boolean`                                                  | `false`                     | Skip the instant-alter attempt and always run pt-osc                                        |
+| `ptoscMinRows`           | `number`                                                   | `undefined`                 | Minimum row count required to use pt-osc; below this, ALTER runs natively                  |
 | `analyzeBeforeSwap`       | `boolean`                                                  | `true`                      | `--analyze-before-swap` or `--noanalyze-before-swap`                                        |
 | `checkAlter`              | `boolean`                                                  | `true`                      | `--check-alter` or `--nocheck-alter`                                                        |
 | `checkForeignKeys`        | `boolean`                                                  | `true`                      | `--check-foreign-keys` or `--nocheck-foreign-keys`                                          |

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export interface PtoscOptions {
   alterForeignKeysMethod?: 'auto' | 'rebuild_constraints' | 'drop_swap' | 'none';
   ptoscPath?: string;
   forcePtosc?: boolean;
+  ptoscMinRows?: number;
   analyzeBeforeSwap?: boolean;
   checkAlter?: boolean;
   checkForeignKeys?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [


### PR DESCRIPTION
## Summary
- allow skipping pt-osc for small tables via `ptoscMinRows`
- document `ptoscMinRows` option and update package version
- test that native alter is used when row count is under threshold

## Testing
- `npm test`
