### PR TITLE
feat: add raw SQL entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 2025-08-22:
 
+**0.2.8**
+
+- Added `alterTableWithPtoscRaw` to run raw `ALTER TABLE` statements.
+
 **0.2.7**
 
 - Changed default `ptoscMinRows` to 0.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ using
 
 This plugin offers an alternative to the normal schema builder, routing the
 `.alterTable()` builder through **pt-online-schema-change** so changes can be
-executed with minimal locking and downtime. Direct raw `ALTER TABLE` strings
-are not supported. For operations that can be run INSTANT in the engine,
-`pt-osc` will not be invoked; instead knex will handle it.
+executed with minimal locking and downtime. It also exposes
+`alterTableWithPtoscRaw` for executing raw `ALTER TABLE` statements. For
+operations that can be run INSTANT in the engine, `pt-osc` will not be invoked;
+instead knex will handle it.
 
 **Github Repo:** https://github.com/gwinans/knex-ptosc-plugin
 
@@ -42,8 +43,8 @@ Please, come contribute! Star the project!
   Table names can be customized with `migrationsTable` and
   `migrationsLockTable`.
 - **Dry-run first**: Always runs a pt-osc `--dry-run` before executing.
-- **Full ALTER support**: Uses Knex’s `.alterTable()` builder syntax; raw
-  `ALTER` strings are not supported.
+- **Full ALTER support**: Works with Knex’s `.alterTable()` builder or raw
+  `ALTER TABLE` strings via `alterTableWithPtoscRaw`.
 - **Respects Knex bindings**: Correctly interpolates values from `.toSQL()`
   output.
 - **Instant alters when possible**: Attempts native
@@ -199,6 +200,19 @@ export function down(knex) {
   return alterTableWithPtosc(knex, 'widgets', (table) => {
     table.integer('qty').alter();
   });
+}
+```
+
+### Raw SQL
+
+```js
+import { alterTableWithPtoscRaw } from 'knex-ptosc-plugin';
+
+export function up(knex) {
+  return alterTableWithPtoscRaw(
+    knex,
+    'ALTER TABLE widgets ALTER COLUMN qty TYPE BIGINT'
+  );
 }
 ```
 

--- a/index.cjs
+++ b/index.cjs
@@ -3,3 +3,5 @@
 // Bridge to the ESM build; functions remain async Promises.
 module.exports.alterTableWithPtosc = (...args) =>
   import('./index.js').then(m => m.alterTableWithPtosc(...args));
+module.exports.alterTableWithPtoscRaw = (...args) =>
+  import('./index.js').then(m => m.alterTableWithPtoscRaw(...args));

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,3 +47,9 @@ export declare function alterTableWithPtosc(
   alterCallback: (tableBuilder: Knex.AlterTableBuilder) => void,
   options?: PtoscOptions
 ): Promise<Record<string, number>[] | undefined>;
+
+export declare function alterTableWithPtoscRaw(
+  knex: Knex,
+  sql: string,
+  ...sqlsOrOptions: Array<string | PtoscOptions>
+): Promise<Record<string, number>[] | undefined>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knex-ptosc-plugin",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [

--- a/test/raw.test.js
+++ b/test/raw.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import child from 'child_process';
+import { PassThrough } from 'stream';
+import { EventEmitter } from 'events';
+import { alterTableWithPtoscRaw } from '../index.js';
+import * as lock from '../src/lock.js';
+
+function createKnex() {
+  const qb = {
+    where: vi.fn().mockReturnThis(),
+    update: vi.fn().mockResolvedValue(1),
+    select: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue({ is_locked: 0 })
+  };
+  const knex = vi.fn().mockReturnValue(qb);
+  knex.client = { config: { connection: { database: 'db', host: 'localhost', user: 'root' } } };
+  knex.raw = vi.fn(sql => {
+    if (/SELECT VERSION/i.test(sql)) return Promise.resolve([{ version: '5.7.42' }]);
+    if (/^ALTER TABLE/i.test(sql)) return Promise.resolve();
+    throw new Error('unexpected sql');
+  });
+  return knex;
+}
+
+describe('alterTableWithPtoscRaw', () => {
+  let spawnSpy;
+  let spawnSyncSpy;
+  let releaseSpy;
+
+  beforeEach(() => {
+    releaseSpy = vi.fn();
+    vi.spyOn(lock, 'acquireMigrationLock').mockResolvedValue({ release: releaseSpy });
+    spawnSyncSpy = vi
+      .spyOn(child, 'spawnSync')
+      .mockReturnValue({ status: 0, stdout: Buffer.from('/usr/bin/pt-online-schema-change\n') });
+    spawnSpy = vi.spyOn(child, 'spawn').mockImplementation(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'ok');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 0);
+      });
+      return proc;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('runs pt-osc for raw alters and releases the lock', async () => {
+    const knex = createKnex();
+    await alterTableWithPtoscRaw(knex, 'ALTER TABLE `users` ADD COLUMN `age` INT');
+    expect(spawnSpy).toHaveBeenCalledTimes(2);
+    expect(releaseSpy).toHaveBeenCalled();
+  });
+
+  it('runs index operations natively', async () => {
+    const sql = 'ALTER TABLE `users` ADD INDEX `idx_age` (`age`)';
+    const knex = createKnex();
+    knex.raw.mockImplementation(sqlArg => {
+      if (sqlArg === sql) return Promise.resolve();
+      throw new Error('unexpected sql');
+    });
+    await alterTableWithPtoscRaw(knex, sql);
+    expect(knex.raw).toHaveBeenCalledWith(sql);
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(spawnSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-ALTER statements', async () => {
+    const knex = createKnex();
+    await expect(alterTableWithPtoscRaw(knex, 'SELECT 1')).rejects.toThrow(/Only ALTER TABLE/);
+    expect(releaseSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `alterTableWithPtoscRaw` for executing raw ALTER TABLE statements
- document and test raw SQL support
- bump version to 0.2.8

## Testing
- `npm test`