### PR TITLE
docs: include options in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,15 +173,25 @@ callback, ensuring all changes use Knex's builder API.
 const { alterTableWithPtosc } = require('knex-ptosc-plugin');
 
 exports.up = function (knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table.bigInteger('qty').alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.bigInteger('qty').alter();
+    },
+    { chunkSize: 5000 }
+  );
 };
 
 exports.down = function (knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table.integer('qty').alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.integer('qty').alter();
+    },
+    { chunkSize: 5000 }
+  );
 };
 ```
 
@@ -191,15 +201,25 @@ exports.down = function (knex) {
 import { alterTableWithPtosc } from 'knex-ptosc-plugin';
 
 export function up(knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table.bigInteger('qty').alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.bigInteger('qty').alter();
+    },
+    { chunkSize: 5000 }
+  );
 }
 
 export function down(knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table.integer('qty').alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.integer('qty').alter();
+    },
+    { chunkSize: 5000 }
+  );
 }
 ```
 
@@ -211,7 +231,8 @@ import { alterTableWithPtoscRaw } from 'knex-ptosc-plugin';
 export function up(knex) {
   return alterTableWithPtoscRaw(
     knex,
-    'ALTER TABLE widgets ALTER COLUMN qty TYPE BIGINT'
+    'ALTER TABLE widgets ALTER COLUMN qty TYPE BIGINT',
+    { chunkSize: 5000 }
   );
 }
 ```


### PR DESCRIPTION
## Summary
- show using `chunkSize` in migration examples

## Testing
- `npm test`