### PR TITLE
test: cover resolvePtoscPath caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 2025-08-22:
 
+**0.2.11**
+
+- Test caching of `resolvePtoscPath` to avoid redundant path lookups.
+
 **0.2.10**
 
 - Test option handling in `alterTableWithPtoscRaw`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knex-ptosc-plugin",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [

--- a/test/ptosc-runner.test.js
+++ b/test/ptosc-runner.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import child from 'child_process';
+import { PassThrough } from 'stream';
+import { EventEmitter } from 'events';
+
+let runPtoscProcess;
+let spawnSyncSpy;
+let spawnSpy;
+
+beforeEach(async () => {
+  vi.resetModules();
+  spawnSyncSpy = vi
+    .spyOn(child, 'spawnSync')
+    .mockReturnValue({ status: 0, stdout: Buffer.from('/usr/bin/pt-online-schema-change\n') });
+  spawnSpy = vi.spyOn(child, 'spawn').mockImplementation(() => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const proc = new EventEmitter();
+    proc.stdout = stdout;
+    proc.stderr = stderr;
+    setImmediate(() => {
+      stdout.emit('data', 'ok');
+      stdout.end();
+      stderr.end();
+      proc.emit('close', 0);
+    });
+    return proc;
+  });
+  ({ runPtoscProcess } = await import('../src/ptosc-runner.js'));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolvePtoscPath caching', () => {
+  it('calls spawnSync once for repeated ptoscPath', async () => {
+    await runPtoscProcess({ ptoscPath: 'pt-online-schema-change', args: [] });
+    await runPtoscProcess({ ptoscPath: 'pt-online-schema-change', args: [] });
+    expect(spawnSyncSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test ensuring resolvePtoscPath caches its result
- bump package version to 0.2.11 and record change in changelog

## Testing
- `npm test`