### PR TITLE
Remove ineffective maxBuffer option from ptosc runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### 2025-08-23:
+
+**0.2.12**
+
+- Remove ineffective `maxBuffer` option from `child_process.spawn`.
+
 ### 2025-08-22:
 
 **0.2.11**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knex-ptosc-plugin",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [

--- a/src/ptosc-runner.js
+++ b/src/ptosc-runner.js
@@ -111,7 +111,7 @@ export async function runPtoscProcess({
   }
 
   const result = await new Promise((resolve, reject) => {
-    const child = childProcess.spawn(resolvedPath, args, { env, maxBuffer });
+    const child = childProcess.spawn(resolvedPath, args, { env });
 
     let stdout = '';
     let stderr = '';

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -205,10 +205,10 @@ describe('knex-ptosc-plugin', () => {
       expect(stderrCall[0]).toContain('err1\nerr2');
     });
 
-    it('passes maxBuffer to spawn', async () => {
+    it('does not pass maxBuffer to spawn', async () => {
       const knex = createKnex();
       await alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { maxBuffer: 1024 });
-      expect(spawnSpy.mock.calls[0][2].maxBuffer).toBe(1024);
+      expect(spawnSpy.mock.calls[0][2].maxBuffer).toBeUndefined();
     });
 
     it('rejects when chunkSize is non-positive', async () => {


### PR DESCRIPTION
## Summary
- avoid passing unused `maxBuffer` option to `child_process.spawn`
- adjust tests to confirm `maxBuffer` isn't forwarded
- bump version to 0.2.12 and record change in changelog

## Testing
- `npm test`