### PR TITLE
test: cover ptoscMinRows and raw pt-osc options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **0.2.12**
 
 - Remove ineffective `maxBuffer` option from `child_process.spawn`.
+- Test `ptoscMinRows` bypass and `chunkSize` forwarding in `alterTableWithPtoscRaw`.
 
 ### 2025-08-22:
 


### PR DESCRIPTION
## Summary
- test that alterTableWithPtoscRaw bypasses pt-osc when below ptoscMinRows and forwards custom chunkSize option
- document new test in changelog

## Testing
- `npm test`