### PR TITLE
refactor: centralize progress parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove ineffective `maxBuffer` option from `child_process.spawn`.
 - Test `ptoscMinRows` bypass and `chunkSize` forwarding in `alterTableWithPtoscRaw`.
+- Extract progress line parsing helper for stdout and stderr.
 
 ### 2025-08-22:
 

--- a/test/ptosc-runner.test.js
+++ b/test/ptosc-runner.test.js
@@ -41,3 +41,27 @@ describe('resolvePtoscPath caching', () => {
     expect(spawnSpy).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('progress parsing', () => {
+  it('handles progress lines from stdout and stderr', async () => {
+    const onProgress = vi.fn();
+    spawnSpy.mockImplementationOnce(() => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const proc = new EventEmitter();
+      proc.stdout = stdout;
+      proc.stderr = stderr;
+      setImmediate(() => {
+        stdout.emit('data', 'Progress: 10% 00:02 remain');
+        stderr.emit('data', 'Progress: 20% 00:01 remain');
+        stdout.end();
+        stderr.end();
+        proc.emit('close', 0);
+      });
+      return proc;
+    });
+    await runPtoscProcess({ args: [], onProgress });
+    expect(onProgress).toHaveBeenCalledWith(10, '00:02');
+    expect(onProgress).toHaveBeenCalledWith(20, '00:01');
+  });
+});


### PR DESCRIPTION
## Summary
- extract `parseProgressLines` helper to handle stdout and stderr progress updates
- test progress parsing across both streams

## Testing
- `npm test`