### PR TITLE
Wait for migration lock to clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove ineffective `maxBuffer` option from `child_process.spawn`.
 - Test `ptoscMinRows` bypass and `chunkSize` forwarding in `alterTableWithPtoscRaw`.
 - Extract progress line parsing helper for stdout and stderr.
+- Wait for existing migration locks to clear instead of treating them as acquired.
 
 ### 2025-08-22:
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Please, come contribute! Star the project!
   environment variable (never on the command line or in logs).
 - **Atomic migration lock**: Uses Knex’s migrations lock row
   (`knex_migrations_lock` by default) to prevent concurrent schema changes.
+  Concurrent callers wait until the lock is released or the timeout elapses.
   Table names can be customized with `migrationsTable` and
   `migrationsLockTable`.
 - **Dry-run first**: Always runs a pt-osc `--dry-run` before executing.
@@ -159,7 +160,8 @@ end-to-end behavior.
 - **Password is hidden**: Never appears in process list, logs, or command
   history.
 - **Atomic locks**: Lock acquisition uses `UPDATE ... WHERE is_locked=0` to
-  avoid stealing locks from another process.
+  avoid stealing locks from another process and waits for existing locks to
+  clear before proceeding.
 - **Dry-run first**: Always verifies the migration before execution.
 
 ---

--- a/src/lock.js
+++ b/src/lock.js
@@ -27,40 +27,36 @@ export async function acquireMigrationLock(
   }
 
   const start = Date.now();
-  let acquired = false;
   let changedRow = false;
 
-  while (!acquired) {
+  while (Date.now() - start <= timeoutMs) {
     const updated = await knex(migrationsLockTable)
       .where({ is_locked: 0 })
       .update({ is_locked: 1 })
       .catch(() => 0);
 
     if (updated === 1) {
-      acquired = true;
       changedRow = true;
       break;
     }
 
+    await sleep(intervalMs);
+  }
+
+  if (!changedRow) {
     const lockRow = await knex(migrationsLockTable)
       .select('is_locked')
       .first()
       .catch(() => ({ is_locked: 0 }));
 
     if (lockRow.is_locked === 1) {
-      acquired = true;
-      break;
-    }
-
-    if (Date.now() - start > timeoutMs) {
       throw new Error(`Timeout acquiring ${migrationsLockTable}`);
     }
-    await sleep(intervalMs);
   }
 
   return {
     release: async () => {
-      if (!acquired || !changedRow) return;
+      if (!changedRow) return;
       await knex(migrationsLockTable)
         .where({ is_locked: 1 })
         .update({ is_locked: 0 })


### PR DESCRIPTION
## Summary
- wait for existing migration locks to clear before acquiring
- document lock waiting behavior
- verify concurrent callers block or time out

## Testing
- `npm test`