### PR TITLE
Validate logger functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Test `ptoscMinRows` bypass and `chunkSize` forwarding in `alterTableWithPtoscRaw`.
 - Extract progress line parsing helper for stdout and stderr.
 - Wait for existing migration locks to clear instead of treating them as acquired.
+- Validate logger methods and throw if they are not functions.
 
 ### 2025-08-22:
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm install knex-ptosc-plugin
 | `checkUniqueKeyChange` | `boolean` | `true` | `--check-unique-key-change` or `--nocheck-unique-key-change` |
 | `maxLag` | `number` | `25` | Passed to `--max-lag` |
 | `maxBuffer` | `number` | `10485760` | `child_process.execFile` `maxBuffer` in bytes |
-| `logger` | `{ log: Function, error: Function }` | `console` | Override default logging methods |
+| `logger` | `{ log: Function, error: Function }` | `console` | Override default logging methods; must provide `log` and `error` functions |
 | `onProgress` | `(pct: number, eta?: string) => void` | `undefined` | Callback for progress percentage and optional ETA parsed from output; logs include pt-osc ETA when available |
 | `statistics` | `boolean` | `false` | Adds `--statistics`; log and collect internal pt-osc counters |
 | `onStatistics` | `(stats: Record<string, number>) => void` | `undefined` | Invoked with parsed statistics object when `statistics` is true |

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,13 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
     onStatistics
   } = options;
 
+  if (typeof logger.log !== 'function') {
+    throw new TypeError('logger.log must be a function');
+  }
+  if (typeof logger.error !== 'function') {
+    throw new TypeError('logger.error must be a function');
+  }
+
   if (maxLoad !== undefined && (!Number.isInteger(maxLoad) || maxLoad <= 0)) {
     throw new TypeError(`maxLoad must be a positive integer, got ${maxLoad}`);
   }

--- a/src/ptosc-runner.js
+++ b/src/ptosc-runner.js
@@ -101,6 +101,13 @@ export async function runPtoscProcess({
   onStatistics,
   printCommand = true,
 }) {
+  if (typeof logger.log !== 'function') {
+    throw new TypeError('logger.log must be a function');
+  }
+  if (typeof logger.error !== 'function') {
+    throw new TypeError('logger.error must be a function');
+  }
+
   const debug = isDebugEnabled();
   const resolvedPath = resolvePtoscPath(ptoscPath);
   const env = { ...process.env };

--- a/test/ptosc-runner.test.js
+++ b/test/ptosc-runner.test.js
@@ -65,3 +65,21 @@ describe('progress parsing', () => {
     expect(onProgress).toHaveBeenCalledWith(20, '00:01');
   });
 });
+
+describe('logger validation', () => {
+  it('throws when logger.log is not a function', async () => {
+    await expect(
+      runPtoscProcess({ args: [], logger: { log: true, error: () => {} } })
+    ).rejects.toThrow(/logger\.log must be a function/);
+    expect(spawnSyncSpy).not.toHaveBeenCalled();
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws when logger.error is not a function', async () => {
+    await expect(
+      runPtoscProcess({ args: [], logger: { log: () => {}, error: true } })
+    ).rejects.toThrow(/logger\.error must be a function/);
+    expect(spawnSyncSpy).not.toHaveBeenCalled();
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -126,6 +126,22 @@ describe('knex-ptosc-plugin', () => {
       expect(consoleSpy).not.toHaveBeenCalled();
     });
 
+    it('throws when logger.log is not a function', async () => {
+      const knex = createKnex();
+      await expect(
+        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { logger: { log: true, error: () => {} } })
+      ).rejects.toThrow(/logger\.log must be a function/);
+      expect(spawnSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws when logger.error is not a function', async () => {
+      const knex = createKnex();
+      await expect(
+        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { logger: { log: () => {}, error: true } })
+      ).rejects.toThrow(/logger\.error must be a function/);
+      expect(spawnSpy).not.toHaveBeenCalled();
+    });
+
     it('surfaces pt-osc errors with code and output', async () => {
       const knex = createKnex();
       spawnSpy.mockImplementationOnce(() => {


### PR DESCRIPTION
## Summary
- ensure custom loggers expose `log` and `error` methods
- document logger requirements
- test that invalid logger objects are rejected

## Testing
- `npm test`