### PR TITLE
feat: stream pt-osc statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 2025-08-23:
 
+**0.2.13**
+
+- Stream statistics line-by-line and invoke `onStatistics` for each update.
+
 **0.2.12**
 
 - Remove ineffective `maxBuffer` option from `child_process.spawn`.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ npm install knex-ptosc-plugin
 | `logger` | `{ log: Function, error: Function }` | `console` | Override default logging methods; must provide `log` and `error` functions |
 | `onProgress` | `(pct: number, eta?: string) => void` | `undefined` | Callback for progress percentage and optional ETA parsed from output; logs include pt-osc ETA when available |
 | `statistics` | `boolean` | `false` | Adds `--statistics`; log and collect internal pt-osc counters |
-| `onStatistics` | `(stats: Record<string, number>) => void` | `undefined` | Invoked with parsed statistics object when `statistics` is true |
+| `onStatistics` | `(stats: Record<string, number>) => void` | `undefined` | Invoked with the cumulative statistics each time a `# key value` line is parsed when `statistics` is true |
 | `migrationsTable` | `string` | `'knex_migrations'` | Overrides migrations table name used for lock checks |
 | `migrationsLockTable` | `string` | `'knex_migrations_lock'` | Overrides migrations lock table name used when acquiring lock |
 | `timeoutMs` | `number` | `30000` | Timeout in ms when acquiring migration lock |
@@ -118,9 +118,20 @@ npm install knex-ptosc-plugin
 
 ### Statistics example
 
-When `statistics: true`, pt-online-schema-change prints internal counters at the
-end of the run. These are parsed into an object, logged via the provided logger,
-and returned (or sent to `onStatistics`). Example output:
+When `statistics: true`, pt-online-schema-change prints internal counters as
+`# key value` lines during the run. These are parsed as they arrive. The
+cumulative object is logged, passed to `onStatistics` on every update, and
+returned when the process exits.
+
+```js
+await runPtoscProcess({
+  args: [],
+  statistics: true,
+  onStatistics: stats => console.log(stats),
+});
+```
+
+Example output:
 
 ```
 # Event          Count

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knex-ptosc-plugin",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [


### PR DESCRIPTION
## Summary
- stream pt-osc statistics and invoke `onStatistics` for each parsed line
- document streaming statistics behavior in the README
- bump version to 0.2.13

## Testing
- `npm test`