### PR TITLE
refactor: add option validation helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **0.2.13**
 
 - Stream statistics line-by-line and invoke `onStatistics` for each update.
+- Validate numeric and boolean options via helper functions.
 
 **0.2.12**
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,12 @@
 import { acquireMigrationLock } from './lock.js';
 import { buildPtoscArgs, runPtoscProcess } from './ptosc-runner.js';
 import { isDebugEnabled } from './debug.js';
+import {
+  validatePositiveInt,
+  validatePositiveNumber,
+  validateNonNegativeInt,
+  validateBoolean
+} from './validators.js';
 
 const VALID_FOREIGN_KEYS_METHODS = ['auto', 'rebuild_constraints', 'drop_swap', 'none'];
 
@@ -63,34 +69,27 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
   if (typeof logger.error !== 'function') {
     throw new TypeError('logger.error must be a function');
   }
+  validatePositiveInt('maxLoad', maxLoad);
+  validatePositiveInt('criticalLoad', criticalLoad);
+  validatePositiveInt('checkInterval', checkInterval);
+  validatePositiveInt('chunkIndexColumns', chunkIndexColumns);
+  validatePositiveInt('chunkSize', chunkSize);
+  validatePositiveNumber('chunkSizeLimit', chunkSizeLimit);
+  validatePositiveNumber('chunkTime', chunkTime);
+  validatePositiveInt('maxLag', maxLag);
+  validatePositiveInt('maxBuffer', maxBuffer);
 
-  if (maxLoad !== undefined && (!Number.isInteger(maxLoad) || maxLoad <= 0)) {
-    throw new TypeError(`maxLoad must be a positive integer, got ${maxLoad}`);
-  }
-  if (criticalLoad !== undefined && (!Number.isInteger(criticalLoad) || criticalLoad <= 0)) {
-    throw new TypeError(`criticalLoad must be a positive integer, got ${criticalLoad}`);
-  }
-  if (checkInterval !== undefined && (!Number.isInteger(checkInterval) || checkInterval <= 0)) {
-    throw new TypeError(`checkInterval must be a positive integer, got ${checkInterval}`);
-  }
-  if (chunkIndexColumns !== undefined && (!Number.isInteger(chunkIndexColumns) || chunkIndexColumns <= 0)) {
-    throw new TypeError(`chunkIndexColumns must be a positive integer, got ${chunkIndexColumns}`);
-  }
-  if (chunkSize !== undefined && (!Number.isInteger(chunkSize) || chunkSize <= 0)) {
-    throw new TypeError(`chunkSize must be a positive integer, got ${chunkSize}`);
-  }
-  if (chunkSizeLimit !== undefined && (typeof chunkSizeLimit !== 'number' || chunkSizeLimit <= 0)) {
-    throw new TypeError(`chunkSizeLimit must be a positive number, got ${chunkSizeLimit}`);
-  }
-  if (chunkTime !== undefined && (typeof chunkTime !== 'number' || chunkTime <= 0)) {
-    throw new TypeError(`chunkTime must be a positive number, got ${chunkTime}`);
-  }
-  if (maxLag !== undefined && (!Number.isInteger(maxLag) || maxLag <= 0)) {
-    throw new TypeError(`maxLag must be a positive integer, got ${maxLag}`);
-  }
-  if (maxBuffer !== undefined && (!Number.isInteger(maxBuffer) || maxBuffer <= 0)) {
-    throw new TypeError(`maxBuffer must be a positive integer, got ${maxBuffer}`);
-  }
+  validateBoolean('analyzeBeforeSwap', analyzeBeforeSwap);
+  validateBoolean('checkAlter', checkAlter);
+  validateBoolean('checkForeignKeys', checkForeignKeys);
+  validateBoolean('checkPlan', checkPlan);
+  validateBoolean('checkReplicationFilters', checkReplicationFilters);
+  validateBoolean('checkReplicaLag', checkReplicaLag);
+  validateBoolean('dropNewTable', dropNewTable);
+  validateBoolean('dropOldTable', dropOldTable);
+  validateBoolean('dropTriggers', dropTriggers);
+  validateBoolean('checkUniqueKeyChange', checkUniqueKeyChange);
+  validateBoolean('statistics', statistics);
   if (!VALID_FOREIGN_KEYS_METHODS.includes(alterForeignKeysMethod)) {
     throw new TypeError(
       `alterForeignKeysMethod must be one of ${VALID_FOREIGN_KEYS_METHODS.join(', ')}; got '${alterForeignKeysMethod}'.`
@@ -207,9 +206,8 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
 async function runAlterClause(knex, table, alterClause, options = {}) {
   const { forcePtosc, ptoscMinRows = 0 } = options;
 
-  if (!Number.isInteger(ptoscMinRows) || ptoscMinRows < 0) {
-    throw new TypeError(`ptoscMinRows must be a non-negative integer, got ${ptoscMinRows}`);
-  }
+  validateBoolean('forcePtosc', forcePtosc);
+  validateNonNegativeInt('ptoscMinRows', ptoscMinRows);
 
   if (ptoscMinRows > 0) {
     const conn = knex.client.config.connection || {};

--- a/src/validators.js
+++ b/src/validators.js
@@ -1,0 +1,23 @@
+export function validatePositiveInt(name, value) {
+  if (value !== undefined && (!Number.isInteger(value) || value <= 0)) {
+    throw new TypeError(`${name} must be a positive integer, got ${value}`);
+  }
+}
+
+export function validatePositiveNumber(name, value) {
+  if (value !== undefined && (typeof value !== 'number' || value <= 0)) {
+    throw new TypeError(`${name} must be a positive number, got ${value}`);
+  }
+}
+
+export function validateNonNegativeInt(name, value) {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new TypeError(`${name} must be a non-negative integer, got ${value}`);
+  }
+}
+
+export function validateBoolean(name, value) {
+  if (value !== undefined && typeof value !== 'boolean') {
+    throw new TypeError(`${name} must be a boolean, got ${value}`);
+  }
+}

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -251,6 +251,60 @@ describe('knex-ptosc-plugin', () => {
       expect(spawnSpy).not.toHaveBeenCalled();
     });
 
+    const positiveIntOptions = ['criticalLoad', 'checkInterval', 'chunkIndexColumns', 'maxLag', 'maxBuffer'];
+    for (const opt of positiveIntOptions) {
+      it(`rejects when ${opt} is non-positive`, async () => {
+        const knex = createKnex();
+        await expect(
+          alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { [opt]: 0 })
+        ).rejects.toThrow(new RegExp(`${opt} must be a positive integer`));
+        expect(spawnSpy).not.toHaveBeenCalled();
+      });
+    }
+
+    const positiveNumberOptions = ['chunkSizeLimit', 'chunkTime'];
+    for (const opt of positiveNumberOptions) {
+      it(`rejects when ${opt} is non-positive`, async () => {
+        const knex = createKnex();
+        await expect(
+          alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { [opt]: 0 })
+        ).rejects.toThrow(new RegExp(`${opt} must be a positive number`));
+        expect(spawnSpy).not.toHaveBeenCalled();
+      });
+    }
+
+    const booleanOptions = [
+      'analyzeBeforeSwap',
+      'checkAlter',
+      'checkForeignKeys',
+      'checkPlan',
+      'checkReplicationFilters',
+      'checkReplicaLag',
+      'dropNewTable',
+      'dropOldTable',
+      'dropTriggers',
+      'checkUniqueKeyChange',
+      'statistics',
+      'forcePtosc'
+    ];
+    for (const opt of booleanOptions) {
+      it(`rejects when ${opt} is not boolean`, async () => {
+        const knex = createKnex();
+        await expect(
+          alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { [opt]: 'yes' })
+        ).rejects.toThrow(new RegExp(`${opt} must be a boolean`));
+        expect(spawnSpy).not.toHaveBeenCalled();
+      });
+    }
+
+    it('rejects when ptoscMinRows is negative', async () => {
+      const knex = createKnex();
+      await expect(
+        alterTableWithPtosc(knex, 'users', (t) => { t.string('age'); }, { ptoscMinRows: -1 })
+      ).rejects.toThrow(/ptoscMinRows must be a non-negative integer/);
+      expect(spawnSpy).not.toHaveBeenCalled();
+    });
+
     it('emits progress updates', async () => {
       const knex = createKnex();
       const onProgress = vi.fn();


### PR DESCRIPTION
## Summary
- centralize numeric and boolean option validation helpers
- validate all ptosc options using helpers
- test validation for all numeric and boolean options

## Testing
- `npm test`