### PR TITLE
Fix migration lock visibility in transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Stream statistics line-by-line and invoke `onStatistics` for each update.
 - Validate numeric and boolean options via helper functions.
+- Acquire migration lock on a non-transactional connection when invoked within a transaction.
 
 **0.2.12**
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Please, come contribute! Star the project!
   environment variable (never on the command line or in logs).
 - **Atomic migration lock**: Uses Knex’s migrations lock row
   (`knex_migrations_lock` by default) to prevent concurrent schema changes.
+  When run inside a transaction, lock queries execute on a separate
+  connection so the change is immediately visible to other sessions.
   Concurrent callers wait until the lock is released or the timeout elapses.
   Table names can be customized with `migrationsTable` and
   `migrationsLockTable`.

--- a/src/lock.js
+++ b/src/lock.js
@@ -16,54 +16,73 @@ export async function acquireMigrationLock(
     logger = console,
   } = {},
 ) {
-  const hasMigrationsTable = await knex.schema.hasTable(migrationsTable);
-  const hasLockTable = await knex.schema.hasTable(migrationsLockTable);
-
-  if (!hasMigrationsTable || !hasLockTable) {
-    throw new Error(
-      'Required Knex migration tables do not exist. ' +
-      `Ensure ${migrationsTable} and ${migrationsLockTable} are created before running pt-osc migrations.`
-    );
-  }
-
-  const start = Date.now();
-  let changedRow = false;
-
-  while (Date.now() - start <= timeoutMs) {
-    const updated = await knex(migrationsLockTable)
-      .where({ is_locked: 0 })
-      .update({ is_locked: 1 })
-      .catch(() => 0);
-
-    if (updated === 1) {
-      changedRow = true;
-      break;
+  let rootKnex;
+  let runner = knex;
+  try {
+    if (knex.isTransaction) {
+      const { knex: createKnex } = await import('knex');
+      rootKnex = createKnex(knex.client.config);
+      runner = rootKnex;
     }
 
-    await sleep(intervalMs);
-  }
+    const hasMigrationsTable = await runner.schema.hasTable(migrationsTable);
+    const hasLockTable = await runner.schema.hasTable(migrationsLockTable);
 
-  if (!changedRow) {
-    const lockRow = await knex(migrationsLockTable)
-      .select('is_locked')
-      .first()
-      .catch(() => ({ is_locked: 0 }));
-
-    if (lockRow.is_locked === 1) {
-      throw new Error(`Timeout acquiring ${migrationsLockTable}`);
+    if (!hasMigrationsTable || !hasLockTable) {
+      throw new Error(
+        'Required Knex migration tables do not exist. ' +
+        `Ensure ${migrationsTable} and ${migrationsLockTable} are created before running pt-osc migrations.`
+      );
     }
-  }
 
-  return {
-    release: async () => {
-      if (!changedRow) return;
-      await knex(migrationsLockTable)
-        .where({ is_locked: 1 })
-        .update({ is_locked: 0 })
-        .catch((err) => {
+    const start = Date.now();
+    let changedRow = false;
+
+    while (Date.now() - start <= timeoutMs) {
+      const updated = await runner(migrationsLockTable)
+        .where({ is_locked: 0 })
+        .update({ is_locked: 1 })
+        .catch(() => 0);
+
+      if (updated === 1) {
+        changedRow = true;
+        break;
+      }
+
+      await sleep(intervalMs);
+    }
+
+    if (!changedRow) {
+      const lockRow = await runner(migrationsLockTable)
+        .select('is_locked')
+        .first()
+        .catch(() => ({ is_locked: 0 }));
+
+      if (lockRow.is_locked === 1) {
+        throw new Error(`Timeout acquiring ${migrationsLockTable}`);
+      }
+    }
+
+    return {
+      release: async () => {
+        if (!changedRow) {
+          if (rootKnex) await rootKnex.destroy();
+          return;
+        }
+        try {
+          await runner(migrationsLockTable)
+            .where({ is_locked: 1 })
+            .update({ is_locked: 0 });
+        } catch (err) {
           logger.error('Failed to release migration lock', err);
           throw err;
-        });
-    },
-  };
+        } finally {
+          if (rootKnex) await rootKnex.destroy();
+        }
+      },
+    };
+  } catch (err) {
+    if (rootKnex) await rootKnex.destroy();
+    throw err;
+  }
 }

--- a/test/lock-transaction.test.js
+++ b/test/lock-transaction.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('knex', () => {
+  const externalKnex = vi.fn();
+  externalKnex.schema = { hasTable: vi.fn().mockResolvedValue(true) };
+  externalKnex.destroy = vi.fn().mockResolvedValue();
+  const qb = {
+    where: vi.fn().mockReturnThis(),
+    update: vi.fn().mockResolvedValue(1),
+    select: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue({ is_locked: 1 })
+  };
+  externalKnex.mockReturnValue(qb);
+  const createKnex = vi.fn(() => externalKnex);
+  return { knex: createKnex, default: createKnex, externalKnex, createKnex };
+}, { virtual: true });
+
+import { acquireMigrationLock } from '../src/lock.js';
+import { externalKnex, createKnex } from 'knex';
+
+describe('acquireMigrationLock within transaction', () => {
+  it('uses a separate connection outside the transaction', async () => {
+    const trx = vi.fn();
+    trx.isTransaction = true;
+    trx.client = { config: {} };
+
+    const lock = await acquireMigrationLock(trx);
+    expect(createKnex).toHaveBeenCalledWith(trx.client.config);
+    expect(externalKnex).toHaveBeenCalled();
+    await lock.release();
+    expect(externalKnex.destroy).toHaveBeenCalled();
+    expect(trx).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- run migration lock queries on a separate connection when invoked inside a transaction
- document lock behavior and cover transaction path with tests

## Testing
- `npm test`