### PR TITLE
Check migrations tables concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Stream statistics line-by-line and invoke `onStatistics` for each update.
 - Validate numeric and boolean options via helper functions.
 - Acquire migration lock on a non-transactional connection when invoked within a transaction.
+- Check migration tables concurrently before acquiring lock.
 
 **0.2.12**
 

--- a/src/lock.js
+++ b/src/lock.js
@@ -25,8 +25,10 @@ export async function acquireMigrationLock(
       runner = rootKnex;
     }
 
-    const hasMigrationsTable = await runner.schema.hasTable(migrationsTable);
-    const hasLockTable = await runner.schema.hasTable(migrationsLockTable);
+    const [hasMigrationsTable, hasLockTable] = await Promise.all([
+      runner.schema.hasTable(migrationsTable),
+      runner.schema.hasTable(migrationsLockTable),
+    ]);
 
     if (!hasMigrationsTable || !hasLockTable) {
       throw new Error(

--- a/test/ptosc.test.js
+++ b/test/ptosc.test.js
@@ -599,6 +599,19 @@ describe('knex-ptosc-plugin', () => {
       );
     });
 
+    it('checks migration tables concurrently', async () => {
+      const resolvers = [];
+      const hasTable = vi.fn(() => new Promise((resolve) => resolvers.push(resolve)));
+      const knex = createKnex();
+      knex.schema.hasTable = hasTable;
+      const lockPromise = acquireMigrationLock(knex);
+      await Promise.resolve();
+      expect(hasTable).toHaveBeenCalledTimes(2);
+      resolvers.forEach((r) => r(true));
+      const lock = await lockPromise;
+      await lock.release();
+    });
+
     it('times out if the lock cannot be acquired', async () => {
       vi.useFakeTimers();
       let locked = true;


### PR DESCRIPTION
## Summary
- fetch migration and lock table existence concurrently to speed up locking
- verify concurrent table checks and preserve lock behavior
- document concurrent table checks in changelog

## Testing
- `npm test`
