### PR TITLE
chore: lazily import knex in migration lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### 2025-08-23:
 
+**0.2.16**
+
+- Lazily import Knex to avoid module resolution errors when not installed.
+
 **0.2.15**
 
 - Import Knex to create a non-transactional connection when acquiring migration locks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [

--- a/src/lock.js
+++ b/src/lock.js
@@ -1,5 +1,3 @@
-import Knex from 'knex';
-
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 /**
@@ -22,7 +20,10 @@ export async function acquireMigrationLock(
   let runner = knex;
   try {
     if (knex.isTransaction) {
-      rootKnex = Knex(knex.client.config);
+      const { default: createKnex } = await import('knex').catch(() => {
+        throw new Error('knex package is required to acquire migration lock within a transaction');
+      });
+      rootKnex = createKnex(knex.client.config);
       runner = rootKnex;
     }
 


### PR DESCRIPTION
## Summary
- defer importing `knex` until acquiring a migration lock within a transaction, avoiding module resolution errors when `knex` isn't installed
- bump package version to 0.2.16
- document lazy import in the changelog

## Testing
- `npm test`