### PR TITLE
Avoid reacquiring migration lock within transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **0.2.16**
 
 - Lazily import Knex to avoid module resolution errors when not installed.
+- Skip re-acquiring the migration lock when it's already held within a transaction.
 
 **0.2.15**
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Please, come contribute! Star the project!
 - **Atomic migration lock**: Uses Knex’s migrations lock row
   (`knex_migrations_lock` by default) to prevent concurrent schema changes.
   When run inside a transaction, lock queries execute on a separate
-  connection so the change is immediately visible to other sessions.
+  connection so the change is immediately visible to other sessions. If the
+  lock is already held (as in Knex migrations), no extra queries are issued.
   Concurrent callers wait until the lock is released or the timeout elapses.
   Table names can be customized with `migrationsTable` and
   `migrationsLockTable`.

--- a/src/lock.js
+++ b/src/lock.js
@@ -19,14 +19,6 @@ export async function acquireMigrationLock(
   let rootKnex;
   let runner = knex;
   try {
-    if (knex.isTransaction) {
-      const { default: createKnex } = await import('knex').catch(() => {
-        throw new Error('knex package is required to acquire migration lock within a transaction');
-      });
-      rootKnex = createKnex(knex.client.config);
-      runner = rootKnex;
-    }
-
     const [hasMigrationsTable, hasLockTable] = await Promise.all([
       runner.schema.hasTable(migrationsTable),
       runner.schema.hasTable(migrationsLockTable),
@@ -37,6 +29,23 @@ export async function acquireMigrationLock(
         'Required Knex migration tables do not exist. ' +
         `Ensure ${migrationsTable} and ${migrationsLockTable} are created before running pt-osc migrations.`
       );
+    }
+
+    if (knex.isTransaction) {
+      const lockRow = await knex(migrationsLockTable)
+        .select('is_locked')
+        .first()
+        .catch(() => ({ is_locked: 0 }));
+
+      if (lockRow.is_locked === 1) {
+        return { release: async () => {} };
+      }
+
+      const { default: createKnex } = await import('knex').catch(() => {
+        throw new Error('knex package is required to acquire migration lock within a transaction');
+      });
+      rootKnex = createKnex(knex.client.config);
+      runner = rootKnex;
     }
 
     const start = Date.now();


### PR DESCRIPTION
## Summary
- Skip re-acquiring migration lock when it is already held inside a transaction
- Document that lock is reused when already held
- Test that no extra connection is created if lock is held

## Testing
- `npm test`