### PR TITLE
Handle MySQL error 4092 with ptosc fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### 2025-08-23:
 
+**0.2.10**
+
+- Handle MySQL error 4092 from `ALGORITHM=INSTANT` by routing the query through
+  `pt-online-schema-change` and add regression test.
+
 **0.2.9**
 
 - Fixed migration lock waiting logic and added Vitest tests for `buildPtoscArgs`

--- a/README.md
+++ b/README.md
@@ -173,15 +173,25 @@ callback, ensuring all changes use Knex's builder API.
 const { alterTableWithPtosc } = require('knex-ptosc-plugin');
 
 exports.up = function (knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table.bigInteger('qty').alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.bigInteger('qty').alter();
+    },
+    { chunkSize: 500 }
+  );
 };
 
 exports.down = function (knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table.integer('qty').alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.integer('qty').alter();
+    },
+    { chunkSize: 500 }
+  );
 };
 ```
 
@@ -191,15 +201,25 @@ exports.down = function (knex) {
 import { alterTableWithPtosc } from 'knex-ptosc-plugin';
 
 export function up(knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table.bigInteger('qty').alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.bigInteger('qty').alter();
+    },
+    { chunkSize: 500 }
+  );
 }
 
 export function down(knex) {
-  return alterTableWithPtosc(knex, 'widgets', (table) => {
-    table.integer('qty').alter();
-  });
+  return alterTableWithPtosc(
+    knex,
+    'widgets',
+    (table) => {
+      table.integer('qty').alter();
+    },
+    { chunkSize: 500 }
+  );
 }
 ```
 
@@ -211,7 +231,8 @@ import { alterTableWithPtoscRaw } from 'knex-ptosc-plugin';
 export function up(knex) {
   return alterTableWithPtoscRaw(
     knex,
-    'ALTER TABLE widgets ALTER COLUMN qty TYPE BIGINT'
+    'ALTER TABLE widgets ALTER COLUMN qty TYPE BIGINT',
+    { statistics: true }
   );
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { buildPtoscArgs, runPtoscProcess } from './ptosc-runner.js';
 import { isDebugEnabled } from './debug.js';
 
 const VALID_FOREIGN_KEYS_METHODS = ['auto', 'rebuild_constraints', 'drop_swap', 'none'];
+const INSTANT_UNSUPPORTED_ERRNOS = [1846, 1847, 4092];
 
 const versionCache = new WeakMap();
 
@@ -242,9 +243,7 @@ async function runAlterClause(knex, table, alterClause, options = {}) {
       } catch (err) {
         const msg = err.message || '';
         if (
-          err.errno === 1846 ||
-          err.errno === 1847 ||
-          err.errno === 4092 ||
+          INSTANT_UNSUPPORTED_ERRNOS.includes(err.errno) ||
           (/ALGORITHM=INSTANT/i.test(msg) && /unsupported|not supported/i.test(msg)) ||
           /Maximum row versions/i.test(msg)
         ) {

--- a/tests/instant-fallback.test.js
+++ b/tests/instant-fallback.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../src/ptosc-runner.js', () => ({
+  buildPtoscArgs: vi.fn(() => []),
+  runPtoscProcess: vi.fn(() => Promise.resolve({ statistics: {} })),
+}));
+
+import { alterTableWithPtoscRaw } from '../src/index.js';
+import { runPtoscProcess } from '../src/ptosc-runner.js';
+
+function createKnexMock() {
+  const knex = () => ({
+    where() { return this; },
+    update: async () => 1,
+    select() { return this; },
+    first: async () => ({ is_locked: 0 }),
+  });
+  knex.schema = { hasTable: async () => true };
+  knex.client = { config: { connection: { database: 'testdb', host: 'localhost', user: 'root' } } };
+  knex.raw = vi.fn((sql) => {
+    if (sql === 'SELECT VERSION() AS version') {
+      return Promise.resolve([{ version: '8.0.0' }]);
+    }
+    if (/ALGORITHM=INSTANT/.test(sql)) {
+      const err = new Error('unsupported');
+      err.errno = 4092;
+      return Promise.reject(err);
+    }
+    return Promise.resolve();
+  });
+  return knex;
+}
+
+describe('INSTANT fallback', () => {
+  it('routes error 4092 through ptosc', async () => {
+    const knex = createKnexMock();
+    await alterTableWithPtoscRaw(knex, 'ALTER TABLE widgets ADD COLUMN foo INT');
+    expect(knex.raw).toHaveBeenCalledWith(expect.stringMatching(/ALGORITHM=INSTANT/));
+    expect(runPtoscProcess).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Refactor error handling so MySQL error 4092 from ALGORITHM=INSTANT triggers a pt-online-schema-change run
- Add regression test for error 4092 fallback
- Include options in README examples

## Testing
- `npm test`
