### PR TITLE
Add runPtoscProcess tests for progress and error cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **0.2.12**
 
 - Added tests for caching and error handling in `resolvePtoscPath`.
+- Added tests for `runPtoscProcess` progress reporting, statistics parsing, and error handling.
 
 **0.2.11**
 


### PR DESCRIPTION
## Summary
- test progress and statistics callbacks in `runPtoscProcess`
- ensure `runPtoscProcess` rejects on buffer overflow
- verify non-zero exits propagate errors with captured output

## Testing
- `npm test`