### PR TITLE
test: verify lock and stats aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **0.2.13**
 
 - Added tests for ptoscMinRows fast path, INSTANT fallback scenarios, and index clause passthrough.
+- Added tests verifying migration lock handling and statistics aggregation for multiple ALTER clauses.
 
 ### 2025-08-23:
 

--- a/tests/index-multi-alter.test.js
+++ b/tests/index-multi-alter.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/ptosc-runner.js', () => ({
+  buildPtoscArgs: vi.fn(() => []),
+  runPtoscProcess: vi.fn(),
+}));
+
+vi.mock('../src/lock.js', () => ({
+  acquireMigrationLock: vi.fn(),
+}));
+
+import { alterTableWithPtosc } from '../src/index.js';
+import { runPtoscProcess } from '../src/ptosc-runner.js';
+import { acquireMigrationLock } from '../src/lock.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function createKnexMock() {
+  const knex = () => ({});
+  knex.client = { config: { connection: { database: 'testdb', host: 'localhost', user: 'root' } } };
+  knex.schema = {
+    alterTable: (name, cb) => {
+      cb({});
+      return {
+        toSQL: () => [
+          { sql: `ALTER TABLE ${name} ADD INDEX idx_foo (foo)` },
+          { sql: `ALTER TABLE ${name} MODIFY COLUMN bar INT NOT NULL` },
+          { sql: `ALTER TABLE ${name} MODIFY COLUMN baz VARCHAR(50)` },
+        ],
+      };
+    },
+  };
+  knex.raw = vi.fn((sql, bindings) => {
+    if (bindings !== undefined) {
+      return { toQuery: () => sql };
+    }
+    return Promise.resolve();
+  });
+  return knex;
+}
+
+describe('alterTableWithPtosc with multiple ALTER statements', () => {
+  it('acquires/releases lock, runs index natively, aggregates ptosc stats', async () => {
+    const release = vi.fn();
+    acquireMigrationLock.mockResolvedValue({ release });
+
+    runPtoscProcess
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ statistics: { first: 1 } })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ statistics: { second: 2 } });
+
+    const knex = createKnexMock();
+    const stats = await alterTableWithPtosc(knex, 'widgets', () => {}, { forcePtosc: true, statistics: true });
+
+    expect(acquireMigrationLock).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+
+    const execCalls = knex.raw.mock.calls.filter(([, bindings]) => bindings === undefined);
+    expect(execCalls).toEqual([["ALTER TABLE widgets ADD INDEX idx_foo (foo)"]]);
+
+    expect(runPtoscProcess).toHaveBeenCalledTimes(4);
+    expect(stats).toEqual([{ first: 1 }, { second: 2 }]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add test covering multiple ALTER clauses, ensuring migration lock acquisition/release and stats aggregation
- document the new test in changelog

## Testing
- `npm test`