### PR TITLE
test: add raw SQL validation and unique index passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added tests for ptoscMinRows fast path, INSTANT fallback scenarios, and index clause passthrough.
 - Added tests verifying migration lock handling and statistics aggregation for multiple ALTER clauses.
+- Added tests validating error handling for raw SQL inputs and UNIQUE index passthrough.
 
 ### 2025-08-23:
 

--- a/tests/index-passthrough.test.js
+++ b/tests/index-passthrough.test.js
@@ -50,6 +50,13 @@ describe('index clause passthrough', () => {
     expect(runPtoscProcess).not.toHaveBeenCalled();
   });
 
+  it('runs ADD UNIQUE KEY via alterTableWithPtoscRaw', async () => {
+    const knex = createKnexMockRaw();
+    await alterTableWithPtoscRaw(knex, 'ALTER TABLE widgets ADD UNIQUE KEY idx_foo (foo)');
+    expect(knex.raw).toHaveBeenCalledWith('ALTER TABLE widgets ADD UNIQUE KEY idx_foo (foo)');
+    expect(runPtoscProcess).not.toHaveBeenCalled();
+  });
+
   it('runs DROP INDEX via alterTableWithPtoscRaw', async () => {
     const knex = createKnexMockRaw();
     await alterTableWithPtoscRaw(knex, 'ALTER TABLE widgets DROP INDEX idx_foo');

--- a/tests/raw-errors.test.js
+++ b/tests/raw-errors.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/ptosc-runner.js', () => ({
+  buildPtoscArgs: vi.fn(() => []),
+  runPtoscProcess: vi.fn(() => Promise.resolve({ statistics: {} })),
+}));
+
+import { alterTableWithPtoscRaw, alterTableWithPtosc } from '../src/index.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function createKnexMockRaw() {
+  const knex = () => ({
+    where() { return this; },
+    update: async () => 1,
+    select() { return this; },
+    first: async () => ({ is_locked: 0 }),
+  });
+  knex.schema = { hasTable: async () => true };
+  knex.raw = vi.fn(() => Promise.resolve());
+  return knex;
+}
+
+function createKnexMockBuilderNoAlter() {
+  const knex = createKnexMockRaw();
+  knex.schema.alterTable = (name, cb) => {
+    cb({});
+    return {
+      toSQL: () => ({ sql: `CREATE TABLE ${name} (id int)` }),
+    };
+  };
+  knex.raw = vi.fn((sql, bindings) => {
+    if (bindings !== undefined) {
+      return { toQuery: () => sql };
+    }
+    return Promise.resolve();
+  });
+  return knex;
+}
+
+describe('input validation', () => {
+  it('throws when no SQL statements are provided to alterTableWithPtoscRaw', async () => {
+    const knex = createKnexMockRaw();
+    await expect(alterTableWithPtoscRaw(knex)).rejects.toThrow('No SQL statements provided.');
+  });
+
+  it('throws when a non-ALTER statement is provided to alterTableWithPtoscRaw', async () => {
+    const knex = createKnexMockRaw();
+    await expect(alterTableWithPtoscRaw(knex, 'DROP TABLE widgets')).rejects.toThrow(
+      'Only ALTER TABLE statements are supported: DROP TABLE widgets'
+    );
+  });
+
+  it('throws when alterTableWithPtosc produces no ALTER clauses', async () => {
+    const knex = createKnexMockBuilderNoAlter();
+    await expect(
+      alterTableWithPtosc(knex, 'widgets', () => {})
+    ).rejects.toThrow(/No ALTER TABLE statements generated/);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests asserting raw SQL input validation for `alterTableWithPtoscRaw`
- ensure unique index ALTERs bypass ptosc and execute via `knex.raw`
- consolidate changelog under 0.2.13 without bumping version

## Testing
- `npm test`