### PR TITLE
Refactor option validation into helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **0.2.14**
 
 - Log and surface errors during migration lock acquisition.
+- Refactored option validation into reusable helpers and added unit tests for invalid values.
 
 ### 2025-08-24:
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { acquireMigrationLock } from './lock.js';
 import { buildPtoscArgs, runPtoscProcess } from './ptosc-runner.js';
 import { isDebugEnabled } from './debug.js';
+import { assertPositiveInteger, assertPositiveNumber } from './validators.js';
 
 const VALID_FOREIGN_KEYS_METHODS = ['auto', 'rebuild_constraints', 'drop_swap', 'none'];
 const INSTANT_UNSUPPORTED_ERRNOS = [1846, 1847, 4092];
@@ -58,33 +59,15 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
     onStatistics
   } = options;
 
-  if (maxLoad !== undefined && (!Number.isInteger(maxLoad) || maxLoad <= 0)) {
-    throw new TypeError(`maxLoad must be a positive integer, got ${maxLoad}`);
-  }
-  if (criticalLoad !== undefined && (!Number.isInteger(criticalLoad) || criticalLoad <= 0)) {
-    throw new TypeError(`criticalLoad must be a positive integer, got ${criticalLoad}`);
-  }
-  if (checkInterval !== undefined && (!Number.isInteger(checkInterval) || checkInterval <= 0)) {
-    throw new TypeError(`checkInterval must be a positive integer, got ${checkInterval}`);
-  }
-  if (chunkIndexColumns !== undefined && (!Number.isInteger(chunkIndexColumns) || chunkIndexColumns <= 0)) {
-    throw new TypeError(`chunkIndexColumns must be a positive integer, got ${chunkIndexColumns}`);
-  }
-  if (chunkSize !== undefined && (!Number.isInteger(chunkSize) || chunkSize <= 0)) {
-    throw new TypeError(`chunkSize must be a positive integer, got ${chunkSize}`);
-  }
-  if (chunkSizeLimit !== undefined && (typeof chunkSizeLimit !== 'number' || chunkSizeLimit <= 0)) {
-    throw new TypeError(`chunkSizeLimit must be a positive number, got ${chunkSizeLimit}`);
-  }
-  if (chunkTime !== undefined && (typeof chunkTime !== 'number' || chunkTime <= 0)) {
-    throw new TypeError(`chunkTime must be a positive number, got ${chunkTime}`);
-  }
-  if (maxLag !== undefined && (!Number.isInteger(maxLag) || maxLag <= 0)) {
-    throw new TypeError(`maxLag must be a positive integer, got ${maxLag}`);
-  }
-  if (maxBuffer !== undefined && (!Number.isInteger(maxBuffer) || maxBuffer <= 0)) {
-    throw new TypeError(`maxBuffer must be a positive integer, got ${maxBuffer}`);
-  }
+  if (maxLoad !== undefined) assertPositiveInteger('maxLoad', maxLoad);
+  if (criticalLoad !== undefined) assertPositiveInteger('criticalLoad', criticalLoad);
+  if (checkInterval !== undefined) assertPositiveInteger('checkInterval', checkInterval);
+  if (chunkIndexColumns !== undefined) assertPositiveInteger('chunkIndexColumns', chunkIndexColumns);
+  if (chunkSize !== undefined) assertPositiveInteger('chunkSize', chunkSize);
+  if (chunkSizeLimit !== undefined) assertPositiveNumber('chunkSizeLimit', chunkSizeLimit);
+  if (chunkTime !== undefined) assertPositiveNumber('chunkTime', chunkTime);
+  if (maxLag !== undefined) assertPositiveInteger('maxLag', maxLag);
+  if (maxBuffer !== undefined) assertPositiveInteger('maxBuffer', maxBuffer);
   if (!VALID_FOREIGN_KEYS_METHODS.includes(alterForeignKeysMethod)) {
     throw new TypeError(
       `alterForeignKeysMethod must be one of ${VALID_FOREIGN_KEYS_METHODS.join(', ')}; got '${alterForeignKeysMethod}'.`
@@ -201,8 +184,8 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
 async function runAlterClause(knex, table, alterClause, options = {}) {
   const { forcePtosc, ptoscMinRows = 0 } = options;
 
-  if (!Number.isInteger(ptoscMinRows) || ptoscMinRows < 0) {
-    throw new TypeError(`ptoscMinRows must be a non-negative integer, got ${ptoscMinRows}`);
+  if (ptoscMinRows !== 0) {
+    assertPositiveInteger('ptoscMinRows', ptoscMinRows);
   }
 
   if (ptoscMinRows > 0) {

--- a/src/validators.js
+++ b/src/validators.js
@@ -1,0 +1,11 @@
+export function assertPositiveInteger(name, value) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive integer, got ${value}`);
+  }
+}
+
+export function assertPositiveNumber(name, value) {
+  if (typeof value !== 'number' || Number.isNaN(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive number, got ${value}`);
+  }
+}

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/ptosc-runner.js', () => ({
+  buildPtoscArgs: vi.fn(() => []),
+  runPtoscProcess: vi.fn(() => Promise.resolve({ statistics: {} })),
+}));
+
+import { alterTableWithPtoscRaw } from '../src/index.js';
+import { assertPositiveInteger, assertPositiveNumber } from '../src/validators.js';
+
+function createKnexMock() {
+  const knex = () => ({
+    where() { return this; },
+    update: async () => 1,
+    select() { return this; },
+    first: async () => ({ is_locked: 0 }),
+  });
+  knex.schema = { hasTable: async () => true };
+  knex.client = { config: { connection: { database: 'testdb', host: 'localhost', user: 'root' } } };
+  knex.raw = vi.fn(() => Promise.resolve());
+  return knex;
+}
+
+describe('option validation', () => {
+  let knex;
+  beforeEach(() => {
+    knex = createKnexMock();
+  });
+
+  it('throws for invalid maxLoad', async () => {
+    await expect(
+      alterTableWithPtoscRaw(knex, 'ALTER TABLE widgets ADD COLUMN foo INT', { maxLoad: 0 })
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it('throws for invalid chunkSizeLimit', async () => {
+    await expect(
+      alterTableWithPtoscRaw(knex, 'ALTER TABLE widgets ADD COLUMN foo INT', { chunkSizeLimit: 0 })
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it('throws for invalid ptoscMinRows', async () => {
+    await expect(
+      alterTableWithPtoscRaw(knex, 'ALTER TABLE widgets ADD COLUMN foo INT', { ptoscMinRows: -1 })
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+});
+
+describe('assert helpers', () => {
+  it('assertPositiveInteger throws on invalid values', () => {
+    expect(() => assertPositiveInteger('test', 0)).toThrow(TypeError);
+    expect(() => assertPositiveInteger('test', -1)).toThrow(TypeError);
+    expect(() => assertPositiveInteger('test', 1.2)).toThrow(TypeError);
+  });
+
+  it('assertPositiveNumber throws on invalid values', () => {
+    expect(() => assertPositiveNumber('test', 0)).toThrow(TypeError);
+    expect(() => assertPositiveNumber('test', -1.2)).toThrow(TypeError);
+    expect(() => assertPositiveNumber('test', 'foo')).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable validators for positive integers and numbers
- refactor option checks to use helpers and cover ptoscMinRows
- test invalid option values

## Testing
- `npm test`