### PR TITLE
Ensure ptosc binary missing error is single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ### 2025-09-11:
 
-**0.2.15**
-
-- Ensure resolvePtoscPath error message is single line and test no newline.
-
 **0.2.14**
 
+- Ensure resolvePtoscPath error message is single line and test no newline.
 - Log and surface errors during migration lock acquisition.
 - Refactored option validation into reusable helpers and added unit tests for invalid values.
 - Consolidated shared pt-osc arguments to remove duplicate code.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.15",
+  "version": "0.2.14",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [

--- a/src/ptosc-runner.js
+++ b/src/ptosc-runner.js
@@ -11,7 +11,8 @@ export function resolvePtoscPath(ptoscPath = 'pt-online-schema-change') {
   if (status !== 0) {
     throw new Error(
       'pt-online-schema-change binary not found: ' +
-        `${ptoscPath}. Install Percona Toolkit and ensure pt-online-schema-change is in your PATH.`
+        ptoscPath +
+        '. Install Percona Toolkit and ensure pt-online-schema-change is in your PATH.'
     );
   }
   const resolved = stdout.toString().trim();

--- a/tests/ptosc-runner.test.js
+++ b/tests/ptosc-runner.test.js
@@ -101,7 +101,7 @@ describe('resolvePtoscPath', () => {
     }
     expect(error).toBeDefined();
     expect(error.message).toMatch(/binary not found: missing-ptosc/);
-    expect(error.message).not.toMatch(/\n/);
+    expect(error.message).not.toContain('\n');
     expect(spawnSpy).toHaveBeenCalledTimes(1);
     spawnSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- keep resolvePtoscPath missing-binary error on a single line
- test resolvePtoscPath error message for newline

## Testing
- `npm test`