### PR TITLE
test: reuse shared knex mock builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **0.2.14**
 
+- Consolidated Knex mock builders into shared test helpers.
 - Ensure resolvePtoscPath error message is single line and test no newline.
 - Log and surface errors during migration lock acquisition.
 - Refactored option validation into reusable helpers and added unit tests for invalid values.

--- a/tests/helpers/knex-mock.js
+++ b/tests/helpers/knex-mock.js
@@ -1,0 +1,68 @@
+import { vi } from 'vitest';
+
+export function createKnexMockRaw(rawImpl = vi.fn(() => Promise.resolve())) {
+  const knex = () => ({
+    where() { return this; },
+    update: async () => 1,
+    select() { return this; },
+    first: async () => ({ is_locked: 0 }),
+  });
+  knex.schema = { hasTable: async () => true };
+  knex.raw = rawImpl;
+  return knex;
+}
+
+export function createKnexMock({ rawImpl = vi.fn(() => Promise.resolve()), clientConfig = { database: 'testdb', host: 'localhost', user: 'root' } } = {}) {
+  const knex = createKnexMockRaw(rawImpl);
+  knex.client = { config: { connection: clientConfig } };
+  return knex;
+}
+
+export function createKnexMockBuilder({
+  toSQL = (name) => ({ sql: `ALTER TABLE ${name} ADD INDEX idx_foo (foo)` }),
+  rawImpl,
+  clientConfig,
+} = {}) {
+  const knex = createKnexMock({ rawImpl: rawImpl ?? vi.fn((sql, bindings) => {
+    if (bindings !== undefined) {
+      return { toQuery: () => sql };
+    }
+    return Promise.resolve();
+  }), clientConfig });
+  knex.schema.alterTable = (name, cb) => {
+    cb({});
+    return { toSQL: () => toSQL(name) };
+  };
+  return knex;
+}
+
+export function createLockKnexMock(initial = 0, opts = {}) {
+  const { updateError = null, selectError = null } = opts;
+  const state = { is_locked: initial };
+  const knex = () => {
+    const builder = {
+      where() { return builder; },
+      update: async (obj) => {
+        if (updateError) throw updateError;
+        if (obj.is_locked === 1 && state.is_locked === 0) {
+          state.is_locked = 1;
+          return 1;
+        }
+        if (obj.is_locked === 0 && state.is_locked === 1) {
+          state.is_locked = 0;
+          return 1;
+        }
+        return 0;
+      },
+      select() { return builder; },
+      first: async () => {
+        if (selectError) throw selectError;
+        return { is_locked: state.is_locked };
+      },
+    };
+    return builder;
+  };
+  knex.schema = { hasTable: async () => true };
+  knex._state = state;
+  return knex;
+}

--- a/tests/ptosc-min-rows.test.js
+++ b/tests/ptosc-min-rows.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createKnexMock } from './helpers/knex-mock.js';
 
 vi.mock('../src/ptosc-runner.js', () => ({
   buildPtoscArgs: vi.fn(() => []),
@@ -12,27 +13,17 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-function createKnexMock() {
-  const knex = () => ({
-    where() { return this; },
-    update: async () => 1,
-    select() { return this; },
-    first: async () => ({ is_locked: 0 }),
-  });
-  knex.schema = { hasTable: async () => true };
-  knex.client = { config: { connection: { database: 'testdb', host: 'localhost', user: 'root' } } };
-  knex.raw = vi.fn((sql) => {
-    if (sql.startsWith('SELECT TABLE_ROWS FROM information_schema.tables')) {
-      return Promise.resolve([{ TABLE_ROWS: 5 }]);
-    }
-    return Promise.resolve();
-  });
-  return knex;
-}
 
 describe('ptoscMinRows fast path', () => {
   it('runs native ALTER when row count below threshold', async () => {
-    const knex = createKnexMock();
+    const knex = createKnexMock({
+      rawImpl: vi.fn((sql) => {
+        if (sql.startsWith('SELECT TABLE_ROWS FROM information_schema.tables')) {
+          return Promise.resolve([{ TABLE_ROWS: 5 }]);
+        }
+        return Promise.resolve();
+      }),
+    });
     await alterTableWithPtoscRaw(knex, 'ALTER TABLE widgets ADD COLUMN foo INT', { ptoscMinRows: 10 });
     expect(knex.raw).toHaveBeenCalledWith(
       'SELECT TABLE_ROWS FROM information_schema.tables WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',

--- a/tests/raw-errors.test.js
+++ b/tests/raw-errors.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createKnexMockRaw, createKnexMockBuilder } from './helpers/knex-mock.js';
 
 vi.mock('../src/ptosc-runner.js', () => ({
   buildPtoscArgs: vi.fn(() => []),
@@ -11,34 +12,6 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-function createKnexMockRaw() {
-  const knex = () => ({
-    where() { return this; },
-    update: async () => 1,
-    select() { return this; },
-    first: async () => ({ is_locked: 0 }),
-  });
-  knex.schema = { hasTable: async () => true };
-  knex.raw = vi.fn(() => Promise.resolve());
-  return knex;
-}
-
-function createKnexMockBuilderNoAlter() {
-  const knex = createKnexMockRaw();
-  knex.schema.alterTable = (name, cb) => {
-    cb({});
-    return {
-      toSQL: () => ({ sql: `CREATE TABLE ${name} (id int)` }),
-    };
-  };
-  knex.raw = vi.fn((sql, bindings) => {
-    if (bindings !== undefined) {
-      return { toQuery: () => sql };
-    }
-    return Promise.resolve();
-  });
-  return knex;
-}
 
 describe('input validation', () => {
   it('throws when no SQL statements are provided to alterTableWithPtoscRaw', async () => {
@@ -54,7 +27,7 @@ describe('input validation', () => {
   });
 
   it('throws when alterTableWithPtosc produces no ALTER clauses', async () => {
-    const knex = createKnexMockBuilderNoAlter();
+    const knex = createKnexMockBuilder({ toSQL: (name) => ({ sql: `CREATE TABLE ${name} (id int)` }) });
     await expect(
       alterTableWithPtosc(knex, 'widgets', () => {})
     ).rejects.toThrow(/No ALTER TABLE statements generated/);

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createKnexMock } from './helpers/knex-mock.js';
 
 vi.mock('../src/ptosc-runner.js', () => ({
   buildPtoscArgs: vi.fn(() => []),
@@ -7,19 +8,6 @@ vi.mock('../src/ptosc-runner.js', () => ({
 
 import { alterTableWithPtoscRaw } from '../src/index.js';
 import { assertPositiveInteger, assertPositiveNumber } from '../src/validators.js';
-
-function createKnexMock() {
-  const knex = () => ({
-    where() { return this; },
-    update: async () => 1,
-    select() { return this; },
-    first: async () => ({ is_locked: 0 }),
-  });
-  knex.schema = { hasTable: async () => true };
-  knex.client = { config: { connection: { database: 'testdb', host: 'localhost', user: 'root' } } };
-  knex.raw = vi.fn(() => Promise.resolve());
-  return knex;
-}
 
 describe('option validation', () => {
   let knex;


### PR DESCRIPTION
## Summary
- extract shared Knex mock builders for tests
- refactor tests to import the helpers

## Testing
- `npm test`