### PR TITLE
test: validate numeric options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### 2025-09-14:
+
+**0.2.14**
+
+- Added tests asserting TypeError for invalid numeric options.
+
 ### 2025-09-11:
 
 **0.2.14**


### PR DESCRIPTION
## Summary
- add tests asserting TypeError for invalid numeric options on ptosc helpers
- note new tests in changelog

## Testing
- `npm test`