### PR TITLE
feat: centralize ptosc option validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+### 2025-09-15:
+
+**0.2.15**
+
+- Centralized ptosc option validation with `validatePtoscOptions` helper.
+
 ### 2025-09-14:
 
 **0.2.14**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.13",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knex-ptosc-plugin",
-      "version": "0.2.13",
+      "version": "0.2.15",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
 import { acquireMigrationLock } from './lock.js';
 import { buildPtoscArgs, runPtoscProcess } from './ptosc-runner.js';
 import { isDebugEnabled } from './debug.js';
-import { assertPositiveInteger, assertPositiveNumber } from './validators.js';
-
-const VALID_FOREIGN_KEYS_METHODS = ['auto', 'rebuild_constraints', 'drop_swap', 'none'];
+import { assertPositiveInteger, validatePtoscOptions } from './validators.js';
 const INSTANT_UNSUPPORTED_ERRNOS = [1846, 1847, 4092];
 
 const versionCache = new WeakMap();
@@ -33,46 +31,31 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}) {
     maxLoadMetric,
     criticalLoad,
     criticalLoadMetric,
-    alterForeignKeysMethod = 'auto',
+    alterForeignKeysMethod,
     ptoscPath,
-    analyzeBeforeSwap = true,
-    checkAlter = true,
-    checkForeignKeys = true,
+    analyzeBeforeSwap,
+    checkAlter,
+    checkForeignKeys,
     checkInterval,
-    checkPlan = true,
-    checkReplicationFilters = true,
-    checkReplicaLag = false,
+    checkPlan,
+    checkReplicationFilters,
+    checkReplicaLag,
     chunkIndex,
     chunkIndexColumns,
-    chunkSize = 1000,
-    chunkSizeLimit = 4.0,
-    chunkTime = 0.5,
-    dropNewTable = true,
-    dropOldTable = true,
-    dropTriggers = true,
-    checkUniqueKeyChange = true,
-    maxLag = 25,
+    chunkSize,
+    chunkSizeLimit,
+    chunkTime,
+    dropNewTable,
+    dropOldTable,
+    dropTriggers,
+    checkUniqueKeyChange,
+    maxLag,
     maxBuffer,
-    logger = console,
+    logger,
     onProgress,
-    statistics = false,
+    statistics,
     onStatistics
-  } = options;
-
-  if (maxLoad !== undefined) assertPositiveInteger('maxLoad', maxLoad);
-  if (criticalLoad !== undefined) assertPositiveInteger('criticalLoad', criticalLoad);
-  if (checkInterval !== undefined) assertPositiveInteger('checkInterval', checkInterval);
-  if (chunkIndexColumns !== undefined) assertPositiveInteger('chunkIndexColumns', chunkIndexColumns);
-  if (chunkSize !== undefined) assertPositiveInteger('chunkSize', chunkSize);
-  if (chunkSizeLimit !== undefined) assertPositiveNumber('chunkSizeLimit', chunkSizeLimit);
-  if (chunkTime !== undefined) assertPositiveNumber('chunkTime', chunkTime);
-  if (maxLag !== undefined) assertPositiveInteger('maxLag', maxLag);
-  if (maxBuffer !== undefined) assertPositiveInteger('maxBuffer', maxBuffer);
-  if (!VALID_FOREIGN_KEYS_METHODS.includes(alterForeignKeysMethod)) {
-    throw new TypeError(
-      `alterForeignKeysMethod must be one of ${VALID_FOREIGN_KEYS_METHODS.join(', ')}; got '${alterForeignKeysMethod}'.`
-    );
-  }
+  } = validatePtoscOptions(options);
 
   const conn = knex.client.config.connection || {};
   const usedPassword = password ?? conn.password;

--- a/src/validators.js
+++ b/src/validators.js
@@ -9,3 +9,86 @@ export function assertPositiveNumber(name, value) {
     throw new TypeError(`${name} must be a positive number, got ${value}`);
   }
 }
+
+const VALID_FOREIGN_KEYS_METHODS = ['auto', 'rebuild_constraints', 'drop_swap', 'none'];
+
+export function validatePtoscOptions(options = {}) {
+  const {
+    password,
+    maxLoad,
+    maxLoadMetric,
+    criticalLoad,
+    criticalLoadMetric,
+    alterForeignKeysMethod = 'auto',
+    ptoscPath,
+    analyzeBeforeSwap = true,
+    checkAlter = true,
+    checkForeignKeys = true,
+    checkInterval,
+    checkPlan = true,
+    checkReplicationFilters = true,
+    checkReplicaLag = false,
+    chunkIndex,
+    chunkIndexColumns,
+    chunkSize = 1000,
+    chunkSizeLimit = 4.0,
+    chunkTime = 0.5,
+    dropNewTable = true,
+    dropOldTable = true,
+    dropTriggers = true,
+    checkUniqueKeyChange = true,
+    maxLag = 25,
+    maxBuffer,
+    logger = console,
+    onProgress,
+    statistics = false,
+    onStatistics
+  } = options;
+
+  if (maxLoad !== undefined) assertPositiveInteger('maxLoad', maxLoad);
+  if (criticalLoad !== undefined) assertPositiveInteger('criticalLoad', criticalLoad);
+  if (checkInterval !== undefined) assertPositiveInteger('checkInterval', checkInterval);
+  if (chunkIndexColumns !== undefined) assertPositiveInteger('chunkIndexColumns', chunkIndexColumns);
+  if (chunkSize !== undefined) assertPositiveInteger('chunkSize', chunkSize);
+  if (chunkSizeLimit !== undefined) assertPositiveNumber('chunkSizeLimit', chunkSizeLimit);
+  if (chunkTime !== undefined) assertPositiveNumber('chunkTime', chunkTime);
+  if (maxLag !== undefined) assertPositiveInteger('maxLag', maxLag);
+  if (maxBuffer !== undefined) assertPositiveInteger('maxBuffer', maxBuffer);
+  if (!VALID_FOREIGN_KEYS_METHODS.includes(alterForeignKeysMethod)) {
+    throw new TypeError(
+      `alterForeignKeysMethod must be one of ${VALID_FOREIGN_KEYS_METHODS.join(', ')}; got '${alterForeignKeysMethod}'.`
+    );
+  }
+
+  return {
+    password,
+    maxLoad,
+    maxLoadMetric,
+    criticalLoad,
+    criticalLoadMetric,
+    alterForeignKeysMethod,
+    ptoscPath,
+    analyzeBeforeSwap,
+    checkAlter,
+    checkForeignKeys,
+    checkInterval,
+    checkPlan,
+    checkReplicationFilters,
+    checkReplicaLag,
+    chunkIndex,
+    chunkIndexColumns,
+    chunkSize,
+    chunkSizeLimit,
+    chunkTime,
+    dropNewTable,
+    dropOldTable,
+    dropTriggers,
+    checkUniqueKeyChange,
+    maxLag,
+    maxBuffer,
+    logger,
+    onProgress,
+    statistics,
+    onStatistics
+  };
+}

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -7,7 +7,7 @@ vi.mock('../src/ptosc-runner.js', () => ({
 }));
 
 import { alterTableWithPtoscRaw, alterTableWithPtosc } from '../src/index.js';
-import { assertPositiveInteger, assertPositiveNumber } from '../src/validators.js';
+import { assertPositiveInteger, assertPositiveNumber, validatePtoscOptions } from '../src/validators.js';
 
 describe('alterTableWithPtoscRaw option validation', () => {
   let knex;
@@ -77,5 +77,18 @@ describe('assert helpers', () => {
     expect(() => assertPositiveNumber('test', 0)).toThrow(TypeError);
     expect(() => assertPositiveNumber('test', -1.2)).toThrow(TypeError);
     expect(() => assertPositiveNumber('test', 'foo')).toThrow(TypeError);
+  });
+});
+
+describe('validatePtoscOptions', () => {
+  it('applies defaults and validates', () => {
+    const opts = validatePtoscOptions({});
+    expect(opts.alterForeignKeysMethod).toBe('auto');
+    expect(opts.chunkSize).toBe(1000);
+    expect(opts.analyzeBeforeSwap).toBe(true);
+  });
+
+  it('throws for invalid alterForeignKeysMethod', () => {
+    expect(() => validatePtoscOptions({ alterForeignKeysMethod: 'invalid' })).toThrow(TypeError);
   });
 });


### PR DESCRIPTION
## Summary
- add `validatePtoscOptions` helper to consolidate pt-osc option defaults and validation
- use new helper in `runAlterClauseWithPtosc`
- test default handling and invalid `alterForeignKeysMethod`

## Testing
- `npm test`