### PR TITLE
Use transactional lock acquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **0.2.15**
 
 - Centralized ptosc option validation with `validatePtoscOptions` helper.
+- Acquire migration lock within a transaction using `SELECT ... FOR UPDATE` to block callers without busy looping.
 
 ### 2025-09-14:
 


### PR DESCRIPTION
## Summary
- acquire the knex migration lock inside a long-lived transaction that issues SELECT ... FOR UPDATE
- expose a release helper that finalizes the transaction and extend the mocks to emulate transactional locking
- expand lock tests to cover concurrent callers and ensure the changelog reflects the new behavior

## Testing
- npm test