### PR TITLE
Use readline for ptosc runner output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Centralized ptosc option validation with `validatePtoscOptions` helper.
 - Acquire migration lock within a transaction using `SELECT ... FOR UPDATE` to block callers without busy looping.
+- Reworked ptosc runner output handling to use readline for progress and statistics parsing.
 
 ### 2025-09-14:
 


### PR DESCRIPTION
## Summary
- replace the manual stdout/stderr buffering in `runPtoscProcess` with readline interfaces so progress and statistics are parsed from line events while preserving maxBuffer enforcement
- update the ptosc runner unit tests to stream line-based output via `PassThrough`, covering progress reporting and stats aggregation
- note the readline-based runner update in the changelog

## Testing
- npm test