### PR TITLE
Add tests for missing ptosc binary and validation errors

### DIFF
--- a/tests/missing-binary.test.js
+++ b/tests/missing-binary.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createKnexMockBuilder } from './helpers/knex-mock.js';
+
+const mocks = vi.hoisted(() => {
+  const resolveError = new Error(
+    'pt-online-schema-change binary not found: test-binary. Install Percona Toolkit and ensure pt-online-schema-change is in your PATH.'
+  );
+  const resolvePtoscPath = vi.fn(() => {
+    throw resolveError;
+  });
+  const runPtoscProcess = vi.fn(async () => {
+    resolvePtoscPath();
+  });
+  const buildPtoscArgs = vi.fn(() => []);
+
+  return { resolveError, resolvePtoscPath, runPtoscProcess, buildPtoscArgs };
+});
+
+vi.mock('../src/ptosc-runner.js', () => ({
+  buildPtoscArgs: mocks.buildPtoscArgs,
+  runPtoscProcess: mocks.runPtoscProcess,
+  resolvePtoscPath: mocks.resolvePtoscPath,
+}));
+
+import { alterTableWithPtosc } from '../src/index.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('alterTableWithPtosc missing binary handling', () => {
+  it('surfaces resolvePtoscPath errors from pt-osc runner', async () => {
+    const knex = createKnexMockBuilder({
+      toSQL: (name) => ({ sql: `ALTER TABLE ${name} ADD COLUMN foo INT` }),
+    });
+
+    await expect(
+      alterTableWithPtosc(knex, 'widgets', () => {}, { forcePtosc: true })
+    ).rejects.toThrow(mocks.resolveError.message);
+
+    expect(mocks.resolvePtoscPath).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/raw-errors.test.js
+++ b/tests/raw-errors.test.js
@@ -32,4 +32,31 @@ describe('input validation', () => {
       alterTableWithPtosc(knex, 'widgets', () => {})
     ).rejects.toThrow(/No ALTER TABLE statements generated/);
   });
+
+  it('throws when an ALTER TABLE statement cannot be parsed', async () => {
+    const knex = createKnexMockRaw();
+    await expect(
+      alterTableWithPtoscRaw(knex, 'ALTER TABLE')
+    ).rejects.toThrow('Unable to parse ALTER TABLE statement: ALTER TABLE');
+  });
+
+  it('throws when alterForeignKeysMethod option is invalid', async () => {
+    const knex = createKnexMockRaw(
+      vi.fn((sql) => {
+        if (/SELECT\s+VERSION\(\)\s+AS\s+version/i.test(sql)) {
+          return Promise.resolve([{ version: '5.7.0' }]);
+        }
+        return Promise.resolve();
+      })
+    );
+    await expect(
+      alterTableWithPtoscRaw(
+        knex,
+        'ALTER TABLE widgets ADD COLUMN foo INT',
+        { alterForeignKeysMethod: 'invalid' }
+      )
+    ).rejects.toThrow(
+      "alterForeignKeysMethod must be one of auto, rebuild_constraints, drop_swap, none; got 'invalid'."
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add a regression test that stubs resolvePtoscPath to ensure alterTableWithPtosc surfaces binary resolution errors
- expand raw error coverage for malformed ALTER statements and invalid alterForeignKeysMethod options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8637bd21c8333a9e0900899bb3cb3