### PR TITLE
Validate pt-osc options before INSTANT alters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+### 2025-10-05:
+
+**0.2.16**
+
+- Validate pt-osc options before attempting INSTANT alters so invalid values throw even when pt-osc is not invoked.
+- Added regression test ensuring invalid pt-osc options fail fast when INSTANT alters succeed.
+
 ### 2025-09-15:
 
 **0.2.15**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knex-ptosc-plugin",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [


### PR DESCRIPTION
## Summary
- validate pt-osc options before attempting INSTANT alters so invalid values fail fast
- add a regression test for invalid options when INSTANT alters succeed and bump the package to 0.2.16 with a changelog entry

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2efc3308c8333934fe8a4735ceff4