### PR TITLE
Fix changelog entry for lock update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Validate pt-osc options before attempting INSTANT alters so invalid values throw even when pt-osc is not invoked.
 - Added regression test ensuring invalid pt-osc options fail fast when INSTANT alters succeed.
+- Prevent `acquireMigrationLock` from overwriting an existing Knex migration lock by requiring `is_locked = 0` during the update.
 
 ### 2025-09-15:
 

--- a/tests/lock.test.js
+++ b/tests/lock.test.js
@@ -82,6 +82,12 @@ describe('acquireMigrationLock', () => {
     expect(logger.error).toHaveBeenCalledWith('Failed to acquire migration lock', error);
   });
 
+  it('refuses to override an existing lock set outside this transaction', async () => {
+    const knex = createLockKnexMock(1, { externalLock: false });
+    await expect(acquireMigrationLock(knex)).rejects.toThrow('Migration lock already held in knex_migrations_lock');
+    expect(knex._state.is_locked).toBe(1);
+  });
+
   it('logs and surfaces errors from lock status read', async () => {
     const error = new Error('select failed');
     const knex = createLockKnexMock(1, { selectError: error });


### PR DESCRIPTION
## Summary
- remove the temporary **Unreleased** section and fold the lock change under the existing 0.2.16 notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e306ad60d48333b891264d5f6ee9b3