### PR TITLE
Codex-generated pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+### 2026-02-17:
+
+**0.2.17**
+
+- Added strict runtime validation for pt-osc option booleans, callbacks, logger methods, and string fields to fail fast on invalid configuration.
+- Validate `forcePtosc` as a boolean before choosing instant-alter vs pt-osc paths.
+- Expanded validator test coverage for new assertion helpers and option-shape validation.
+
 ### 2025-10-05:
 
 **0.2.16**

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npm install knex-ptosc-plugin
 | `dropTriggers` | `boolean` | `true` | `--drop-triggers` or `--nodrop-triggers` |
 | `checkUniqueKeyChange` | `boolean` | `true` | `--check-unique-key-change` or `--nocheck-unique-key-change` |
 | `maxLag` | `number` | `25` | Passed to `--max-lag` |
-| `maxBuffer` | `number` | `10485760` | `child_process.execFile` `maxBuffer` in bytes |
+| `maxBuffer` | `number` | `10485760` | Combined stdout/stderr capture limit in bytes |
 | `logger` | `{ log: Function, error: Function }` | `console` | Override default logging methods |
 | `onProgress` | `(pct: number, eta?: string) => void` | `undefined` | Callback for progress percentage and optional ETA parsed from output; logs include pt-osc ETA when available |
 | `statistics` | `boolean` | `false` | Adds `--statistics`; log and collect internal pt-osc counters |
@@ -115,6 +115,9 @@ npm install knex-ptosc-plugin
 | `migrationsLockTable` | `string` | `'knex_migrations_lock'` | Overrides migrations lock table name used when acquiring lock |
 | `timeoutMs` | `number` | `30000` | Timeout in ms when acquiring migration lock |
 | `intervalMs` | `number` | `500` | Delay between lock retries in ms |
+
+All options are validated up front. Invalid booleans, callbacks, logger methods,
+or empty string values now throw a `TypeError` before migrations start.
 
 ### Statistics example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knex-ptosc-plugin",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-ptosc-plugin",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "type": "module",
   "description": "Knex plugin to run migrations with ptosc",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { acquireMigrationLock } from './lock.js';
 import { buildPtoscArgs, runPtoscProcess } from './ptosc-runner.js';
 import { isDebugEnabled } from './debug.js';
-import { assertPositiveInteger, validatePtoscOptions } from './validators.js';
+import { assertBoolean, assertPositiveInteger, validatePtoscOptions } from './validators.js';
 const INSTANT_UNSUPPORTED_ERRNOS = [1846, 1847, 4092];
 
 const versionCache = new WeakMap();
@@ -138,6 +138,10 @@ async function runAlterClauseWithPtosc(knex, table, alterClause, options = {}, v
 async function runAlterClause(knex, table, alterClause, options = {}) {
   const validatedOptions = validatePtoscOptions(options);
   const { forcePtosc, ptoscMinRows = 0 } = options;
+
+  if (forcePtosc !== undefined) {
+    assertBoolean('forcePtosc', forcePtosc);
+  }
 
   if (ptoscMinRows !== 0) {
     assertPositiveInteger('ptoscMinRows', ptoscMinRows);

--- a/src/validators.js
+++ b/src/validators.js
@@ -10,6 +10,24 @@ export function assertPositiveNumber(name, value) {
   }
 }
 
+export function assertBoolean(name, value) {
+  if (typeof value !== 'boolean') {
+    throw new TypeError(`${name} must be a boolean, got ${value}`);
+  }
+}
+
+export function assertNonEmptyString(name, value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new TypeError(`${name} must be a non-empty string, got ${value}`);
+  }
+}
+
+export function assertFunction(name, value) {
+  if (typeof value !== 'function') {
+    throw new TypeError(`${name} must be a function, got ${value}`);
+  }
+}
+
 const VALID_FOREIGN_KEYS_METHODS = ['auto', 'rebuild_constraints', 'drop_swap', 'none'];
 
 export function validatePtoscOptions(options = {}) {
@@ -46,7 +64,9 @@ export function validatePtoscOptions(options = {}) {
   } = options;
 
   if (maxLoad !== undefined) assertPositiveInteger('maxLoad', maxLoad);
+  if (maxLoadMetric !== undefined) assertNonEmptyString('maxLoadMetric', maxLoadMetric);
   if (criticalLoad !== undefined) assertPositiveInteger('criticalLoad', criticalLoad);
+  if (criticalLoadMetric !== undefined) assertNonEmptyString('criticalLoadMetric', criticalLoadMetric);
   if (checkInterval !== undefined) assertPositiveInteger('checkInterval', checkInterval);
   if (chunkIndexColumns !== undefined) assertPositiveInteger('chunkIndexColumns', chunkIndexColumns);
   if (chunkSize !== undefined) assertPositiveInteger('chunkSize', chunkSize);
@@ -54,6 +74,30 @@ export function validatePtoscOptions(options = {}) {
   if (chunkTime !== undefined) assertPositiveNumber('chunkTime', chunkTime);
   if (maxLag !== undefined) assertPositiveInteger('maxLag', maxLag);
   if (maxBuffer !== undefined) assertPositiveInteger('maxBuffer', maxBuffer);
+  if (ptoscPath !== undefined) assertNonEmptyString('ptoscPath', ptoscPath);
+  if (chunkIndex !== undefined) assertNonEmptyString('chunkIndex', chunkIndex);
+
+  if (typeof logger !== 'object' || logger == null) {
+    throw new TypeError(`logger must be an object with log/error methods, got ${logger}`);
+  }
+  assertFunction('logger.log', logger.log);
+  assertFunction('logger.error', logger.error);
+
+  if (onProgress !== undefined) assertFunction('onProgress', onProgress);
+  if (onStatistics !== undefined) assertFunction('onStatistics', onStatistics);
+
+  assertBoolean('analyzeBeforeSwap', analyzeBeforeSwap);
+  assertBoolean('checkAlter', checkAlter);
+  assertBoolean('checkForeignKeys', checkForeignKeys);
+  assertBoolean('checkPlan', checkPlan);
+  assertBoolean('checkReplicationFilters', checkReplicationFilters);
+  assertBoolean('checkReplicaLag', checkReplicaLag);
+  assertBoolean('dropNewTable', dropNewTable);
+  assertBoolean('dropOldTable', dropOldTable);
+  assertBoolean('dropTriggers', dropTriggers);
+  assertBoolean('checkUniqueKeyChange', checkUniqueKeyChange);
+  assertBoolean('statistics', statistics);
+
   if (!VALID_FOREIGN_KEYS_METHODS.includes(alterForeignKeysMethod)) {
     throw new TypeError(
       `alterForeignKeysMethod must be one of ${VALID_FOREIGN_KEYS_METHODS.join(', ')}; got '${alterForeignKeysMethod}'.`

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -7,7 +7,14 @@ vi.mock('../src/ptosc-runner.js', () => ({
 }));
 
 import { alterTableWithPtoscRaw, alterTableWithPtosc } from '../src/index.js';
-import { assertPositiveInteger, assertPositiveNumber, validatePtoscOptions } from '../src/validators.js';
+import {
+  assertBoolean,
+  assertFunction,
+  assertNonEmptyString,
+  assertPositiveInteger,
+  assertPositiveNumber,
+  validatePtoscOptions,
+} from '../src/validators.js';
 
 describe('alterTableWithPtoscRaw option validation', () => {
   let knex;
@@ -42,6 +49,13 @@ describe('alterTableWithPtoscRaw option validation', () => {
   it('throws for invalid ptoscMinRows', async () => {
     await expect(
       alterTableWithPtoscRaw(knex, 'ALTER TABLE widgets ADD COLUMN foo INT', { ptoscMinRows: -1 })
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+
+  it('throws for invalid forcePtosc', async () => {
+    await expect(
+      alterTableWithPtoscRaw(knex, 'ALTER TABLE widgets ADD COLUMN foo INT', { forcePtosc: 'yes' })
     ).rejects.toBeInstanceOf(TypeError);
   });
 
@@ -98,6 +112,19 @@ describe('assert helpers', () => {
     expect(() => assertPositiveNumber('test', -1.2)).toThrow(TypeError);
     expect(() => assertPositiveNumber('test', 'foo')).toThrow(TypeError);
   });
+
+  it('assertBoolean throws on non-booleans', () => {
+    expect(() => assertBoolean('test', 'true')).toThrow(TypeError);
+  });
+
+  it('assertNonEmptyString throws on empty strings', () => {
+    expect(() => assertNonEmptyString('test', '')).toThrow(TypeError);
+    expect(() => assertNonEmptyString('test', '   ')).toThrow(TypeError);
+  });
+
+  it('assertFunction throws on non-functions', () => {
+    expect(() => assertFunction('test', 123)).toThrow(TypeError);
+  });
 });
 
 describe('validatePtoscOptions', () => {
@@ -110,5 +137,23 @@ describe('validatePtoscOptions', () => {
 
   it('throws for invalid alterForeignKeysMethod', () => {
     expect(() => validatePtoscOptions({ alterForeignKeysMethod: 'invalid' })).toThrow(TypeError);
+  });
+
+  it('throws for invalid logger shape', () => {
+    expect(() => validatePtoscOptions({ logger: {} })).toThrow(/logger\.log/);
+  });
+
+  it('throws for invalid callback options', () => {
+    expect(() => validatePtoscOptions({ onProgress: 'nope' })).toThrow(/onProgress/);
+    expect(() => validatePtoscOptions({ onStatistics: 'nope' })).toThrow(/onStatistics/);
+  });
+
+  it('throws for invalid boolean options', () => {
+    expect(() => validatePtoscOptions({ checkPlan: 'true' })).toThrow(/checkPlan/);
+  });
+
+  it('throws for invalid string options', () => {
+    expect(() => validatePtoscOptions({ ptoscPath: '' })).toThrow(/ptoscPath/);
+    expect(() => validatePtoscOptions({ maxLoadMetric: '' })).toThrow(/maxLoadMetric/);
   });
 });


### PR DESCRIPTION
* Reviewed and improved code quality by hardening runtime option validation in `validatePtoscOptions`, adding explicit checks for booleans, callbacks, logger shape, and required non-empty string fields (`ptoscPath`, `metrics`, `chunkIndex`) so invalid configs fail fast with clear TypeErrors.
* Added forcePtosc type validation in the main ALTER execution flow to prevent non-boolean values from silently affecting INSTANT vs pt-osc behavior.
* Expanded test coverage for the new validation helpers and invalid option shapes, including a regression test for bad forcePtosc input.
* Updated docs to reflect stricter option validation behavior and clarified maxBuffer wording.
* Bumped package version to 0.2.17 and recorded the release notes in CHANGELOG.md using the Phoenix-local date format.
